### PR TITLE
Add pyproject and package setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Evolve
+
+Utilities for converting Itaú credit-card statements from PDF to CSV.
+
+## Development setup
+
+Create a virtual environment and install the package in editable mode with the development extras:
+
+```bash
+pip install -e .[dev]
+```
+
+This installs `pdfplumber` and all tools required by the CI workflow (pytest, coverage, ruff, black and mypy).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "statement_refinery"
+version = "0.1.0"
+description = "PDF to CSV parser for Itaú credit-card statements"
+authors = [{name = "Evolve"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pdfplumber"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "black",
+    "mypy"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Iterator, List
 
 import pdfplumber                               # pip install pdfplumber
-from . import text_to_csv as t2c                # existing legacy parser
+from . import txt_to_csv as t2c                 # existing legacy parser
 
 CSV_HEADER = [
     "card_last4",


### PR DESCRIPTION
## Summary
- set up project metadata in a new `pyproject.toml`
- turn `statement_refinery` into a proper package
- fix import name in `pdf_to_csv`
- document editable install instructions

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `PYTHONPATH=src pytest -q` *(fails: Mismatch for itau_2024-10.pdf)*

------
https://chatgpt.com/codex/tasks/task_e_6840e287f4208327a6200379ef5d3f6b