### PR TITLE
Add packaging basics and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.eggs/
+*.egg-info/
+ENV/
+venv/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# Evolve
+# Statement Refinery
+
+This project provides utilities for converting Ita\u00fa credit card statements into structured CSV files. The main goal is to make transaction data easy to analyze with spreadsheet software or other tools.
+
+## Installation
+
+After cloning the repository, install the package in editable mode along with development dependencies:
+
+```bash
+pip install -e .[dev]
+```
+
+## Command-Line Usage
+
+To convert a PDF statement to CSV, run:
+
+```bash
+python -m statement_refinery.pdf_to_csv input.pdf --out output.csv
+```
+
+The `--out` option specifies where the CSV will be written. If omitted, the CSV is printed to `stdout`.
+
+## Running the Tests
+
+Execute the test suite with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "statement_refinery"
+version = "0.1.0"
+description = "Utilities to convert Itaú credit card statements to CSV"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pdfplumber",
+    "ruff",
+    "black",
+    "mypy",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-data]
+"statement_refinery" = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/statement_refinery/__init__.py
+++ b/src/statement_refinery/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities to convert Itaú credit card statements."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add packaging metadata and a minimal package init
- ignore typical build artifacts
- document installation, CLI usage and running tests

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ImportError: cannot import name 'text_to_csv')*
- `pip install -e .[dev]` *(fails to install dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4a7c1b8832794db4d4e928f08d1