### PR TITLE
chore: clean up trailing blank lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,3 @@ dev = [
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = ["statement_refinery"]
-

--- a/tests/test_pdf_to_csv.py
+++ b/tests/test_pdf_to_csv.py
@@ -45,4 +45,3 @@ def test_all_pdfs(tmp_path):
         assert filecmp.cmp(
             out_csv, golden, shallow=False
         ), f"Mismatch for {pdf.name}"
-


### PR DESCRIPTION
## Summary
- remove extraneous newline from `pyproject.toml`
- drop blank line at end of `tests/test_pdf_to_csv.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840efb0cb04832780ac3097b1dcf52a