### PR TITLE
Remove path manipulation lines from tests

### DIFF
--- a/tests/test_parse_line.py
+++ b/tests/test_parse_line.py
@@ -1,11 +1,6 @@
 import hashlib
 from decimal import Decimal
-from pathlib import Path
-import sys
-
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 from statement_refinery.txt_to_csv import parse_statement_line
 
 

--- a/tests/test_txt_to_csv.py
+++ b/tests/test_txt_to_csv.py
@@ -1,9 +1,4 @@
-import sys
-from pathlib import Path
 from decimal import Decimal
-
-# ensure src on path
-sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from statement_refinery.txt_to_csv import parse_statement_line
 


### PR DESCRIPTION
## Summary
- clean up test imports by dropping manual `sys.path` tweaks
- ensure tests still contain trailing newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0c885b08327b8021ac8fc4fbc2d