### PR TITLE
Format all Python files with black

### DIFF
--- a/.github/tools/codex_patch.py
+++ b/.github/tools/codex_patch.py
@@ -24,10 +24,12 @@ def main():
     print("⚙️  Generating single Codex patch…")
     resp = openai.ChatCompletion.create(
         model=MODEL,
-        messages=[{
-            "role": "user",
-            "content": "There are pytest failures; provide a unified diff that fixes them."
-        }],
+        messages=[
+            {
+                "role": "user",
+                "content": "There are pytest failures; provide a unified diff that fixes them.",
+            }
+        ],
         temperature=0.1,
     )
     patch = resp.choices[0].message["content"]
@@ -45,11 +47,17 @@ def main():
     sh("git", "checkout", "-b", branch)
     sh("git", "push", "-u", "origin", branch)
     sh(
-        "gh", "pr", "create",
-        "--base", os.getenv("GITHUB_HEAD_REF", "main"),
-        "--head", branch,
-        "--title", "🤖 One-shot Codex patch",
-        "--body", "Generated automatically."
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        os.getenv("GITHUB_HEAD_REF", "main"),
+        "--head",
+        branch,
+        "--title",
+        "🤖 One-shot Codex patch",
+        "--body",
+        "Generated automatically.",
     )
     print("PR opened.")
     return 0

--- a/.github/tools/evolve.py
+++ b/.github/tools/evolve.py
@@ -28,7 +28,7 @@ from typing import Tuple
 
 import openai
 
-ROOT = Path(__file__).resolve().parents[2]      # repo root
+ROOT = Path(__file__).resolve().parents[2]  # repo root
 BEST_BRANCH = "codex/best"
 SCORE_FILE = ROOT / ".github/tools/score_best.json"
 openai.api_key = os.environ["OPENAI_API_KEY"]
@@ -51,7 +51,13 @@ def current_commit() -> str:
 def run_tests() -> Tuple[bool, float]:
     """Run pytest + coverage; return (green?, coverage%)."""
     try:
-        out = sh("pytest", "-q", "--cov=statement_refinery", "--cov-report=term-missing", capture=True)
+        out = sh(
+            "pytest",
+            "-q",
+            "--cov=statement_refinery",
+            "--cov-report=term-missing",
+            capture=True,
+        )
     except subprocess.CalledProcessError as exc:
         return False, 0.0
 

--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -6,6 +6,7 @@ CLI
 ---
 python -m statement_refinery.pdf_to_csv input.pdf [--out output.csv]
 """
+
 from __future__ import annotations
 
 import argparse

--- a/src/statement_refinery/txt_to_csv.py
+++ b/src/statement_refinery/txt_to_csv.py
@@ -392,7 +392,15 @@ def parse_statement_line(line: str) -> dict | None:
 
 ITAU_PARSING_RULES = {
     "currency_formats": ["USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD"],
-    "skip_keywords": ["PAGAMENTO", "TOTAL", "JUROS", "MULTA", "LIMITE", "VENCIMENTO", "FATURA"],
+    "skip_keywords": [
+        "PAGAMENTO",
+        "TOTAL",
+        "JUROS",
+        "MULTA",
+        "LIMITE",
+        "VENCIMENTO",
+        "FATURA",
+    ],
     "merchant_separators": [".", "*", "-", " "],
     "amount_validation": {
         "min_adjustment": Decimal("0.01"),

--- a/tests/test_pdf_to_csv.py
+++ b/tests/test_pdf_to_csv.py
@@ -42,6 +42,4 @@ def test_all_pdfs(tmp_path):
         out_csv = tmp_path / golden.name
         run_parser(pdf, out_csv)
 
-        assert filecmp.cmp(
-            out_csv, golden, shallow=False
-        ), f"Mismatch for {pdf.name}"
+        assert filecmp.cmp(out_csv, golden, shallow=False), f"Mismatch for {pdf.name}"

--- a/tests/test_txt_to_csv.py
+++ b/tests/test_txt_to_csv.py
@@ -6,7 +6,7 @@ from statement_refinery.txt_to_csv import parse_statement_line
 def test_parse_domestic():
     line = "28/09 FARMACIA SAO JOAO final 6853 20,00"
     row = parse_statement_line(line)
-    year = __import__('datetime').date.today().year
+    year = __import__("datetime").date.today().year
     assert row == {
         "card_last4": "6853",
         "post_date": f"{year}-09-28",
@@ -18,7 +18,7 @@ def test_parse_domestic():
         "iof_brl": Decimal("0.00"),
         "category": "FARMÁCIA",
         "merchant_city": "",
-        "ledger_hash": __import__('hashlib').sha1(line.encode()).hexdigest(),
+        "ledger_hash": __import__("hashlib").sha1(line.encode()).hexdigest(),
         "prev_bill_amount": Decimal("0.00"),
         "interest_amount": Decimal("0.00"),
         "amount_orig": Decimal("0.00"),
@@ -28,11 +28,9 @@ def test_parse_domestic():
 
 
 def test_parse_international():
-    line = (
-        "10/04 SumUp *BOTI SRL 7,90 56,12 final 6853 EUR 7,90 = 6,27 BRL Milano"
-    )
+    line = "10/04 SumUp *BOTI SRL 7,90 56,12 final 6853 EUR 7,90 = 6,27 BRL Milano"
     row = parse_statement_line(line)
-    year = __import__('datetime').date.today().year
+    year = __import__("datetime").date.today().year
     assert row == {
         "card_last4": "6853",
         "post_date": f"{year}-04-10",
@@ -44,7 +42,7 @@ def test_parse_international():
         "iof_brl": Decimal("0.00"),
         "category": "FX",
         "merchant_city": "Milano",
-        "ledger_hash": __import__('hashlib').sha1(line.encode()).hexdigest(),
+        "ledger_hash": __import__("hashlib").sha1(line.encode()).hexdigest(),
         "prev_bill_amount": Decimal("0.00"),
         "interest_amount": Decimal("0.00"),
         "amount_orig": Decimal("7.90"),
@@ -56,7 +54,7 @@ def test_parse_international():
 def test_parse_payment():
     line = "22/04 PAGAMENTO final 0000 -500,00"
     row = parse_statement_line(line)
-    year = __import__('datetime').date.today().year
+    year = __import__("datetime").date.today().year
     assert row == {
         "card_last4": "0000",
         "post_date": f"{year}-04-22",
@@ -68,7 +66,7 @@ def test_parse_payment():
         "iof_brl": Decimal("0.00"),
         "category": "PAGAMENTO",
         "merchant_city": "",
-        "ledger_hash": __import__('hashlib').sha1(line.encode()).hexdigest(),
+        "ledger_hash": __import__("hashlib").sha1(line.encode()).hexdigest(),
         "prev_bill_amount": Decimal("0.00"),
         "interest_amount": Decimal("0.00"),
         "amount_orig": Decimal("0.00"),
@@ -80,7 +78,7 @@ def test_parse_payment():
 def test_parse_adjustment():
     line = "17/03 MP*BECLOT final 3549 -0,01"
     row = parse_statement_line(line)
-    year = __import__('datetime').date.today().year
+    year = __import__("datetime").date.today().year
     assert row == {
         "card_last4": "3549",
         "post_date": f"{year}-03-17",
@@ -92,7 +90,7 @@ def test_parse_adjustment():
         "iof_brl": Decimal("0.00"),
         "category": "AJUSTE",
         "merchant_city": "",
-        "ledger_hash": __import__('hashlib').sha1(line.encode()).hexdigest(),
+        "ledger_hash": __import__("hashlib").sha1(line.encode()).hexdigest(),
         "prev_bill_amount": Decimal("0.00"),
         "interest_amount": Decimal("0.00"),
         "amount_orig": Decimal("0.00"),


### PR DESCRIPTION
## Summary
- run `black` on repository to standardize formatting

## Testing
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840f32b3a308327a6ef751a6cdb8869