### PR TITLE
Remove duplicate parse_statement_line

### DIFF
--- a/src/statement_refinery/txt_to_csv.py
+++ b/src/statement_refinery/txt_to_csv.py
@@ -17,6 +17,7 @@ import re
 import hashlib
 from decimal import Decimal
 from typing import Final
+from datetime import date
 
 # ===== CORE REGEX PATTERNS =====
 
@@ -159,93 +160,6 @@ def _make_ledger_hash(card: str, date: str, desc: str, amount: Decimal) -> str:
     raw = f"{card}|{date}|{desc}|{amount}"
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
-
-def parse_statement_line(line: str) -> dict | None:
-    """Parse a single statement line into a row dictionary.
-
-    The function understands domestic transactions, foreign exchange lines,
-    payments and adjustments. It relies solely on the regex patterns and
-    helper functions defined in this module.  The returned dictionary contains
-    all keys required by :data:`statement_refinery.pdf_to_csv.CSV_HEADER`.
-    """
-
-    line = line.strip()
-    if not line:
-        return None
-
-    fx_line1 = line
-    fx_line2 = ""
-    if "\n" in line:
-        fx_line1, fx_line2 = line.split("\n", 1)
-
-    # --- Foreign exchange transaction ---
-    mfx = RE_FX_LINE1.match(fx_line1)
-    if mfx:
-        date = mfx.group("date")
-        desc = mfx.group("descr").strip()
-        amount_orig = parse_amount(mfx.group("orig"))
-        amount_brl = parse_amount(mfx.group("brl"))
-
-        currency, fx_rate, city = parse_fx_currency_line(fx_line2)
-        fx_rate_val = parse_amount(fx_rate) if fx_rate else Decimal("0.00")
-
-        seq, tot = extract_installment_info(desc)
-        card_match = RE_CARD_FINAL.search(line)
-        card_last4 = card_match.group(1) if card_match else ""
-
-        row = {
-            "card_last4": card_last4,
-            "post_date": date,
-            "desc_raw": desc,
-            "amount_brl": amount_brl,
-            "installment_seq": seq or 0,
-            "installment_tot": tot or 0,
-            "fx_rate": fx_rate_val,
-            "iof_brl": Decimal("0.00"),
-            "category": classify_transaction(desc, amount_brl),
-            "merchant_city": city or "",
-            "ledger_hash": _make_ledger_hash(card_last4, date, desc, amount_brl),
-            "prev_bill_amount": Decimal("0"),
-            "interest_amount": Decimal("0"),
-            "amount_orig": amount_orig,
-            "currency_orig": currency or "",
-            "amount_usd": Decimal("0.00"),
-        }
-        return row
-
-    # --- Domestic / payment / adjustment ---
-    mdom = RE_DOM_STRICT.match(line) or RE_DOM_TOLERANT.match(line)
-    if not mdom:
-        return None
-
-    date = mdom.group("date")
-    desc_group = mdom.groupdict().get("desc") or mdom.group(2)
-    desc = RE_CARD_FINAL.sub("", desc_group).strip()
-    amount_brl = parse_amount(mdom.group("amt"))
-
-    seq, tot = extract_installment_info(desc)
-    card_match = RE_CARD_FINAL.search(line)
-    card_last4 = card_match.group(1) if card_match else ""
-
-    row = {
-        "card_last4": card_last4,
-        "post_date": date,
-        "desc_raw": desc,
-        "amount_brl": amount_brl,
-        "installment_seq": seq or 0,
-        "installment_tot": tot or 0,
-        "fx_rate": Decimal("0.00"),
-        "iof_brl": Decimal("0.00"),
-        "category": classify_transaction(desc, amount_brl),
-        "merchant_city": "",
-        "ledger_hash": _make_ledger_hash(card_last4, date, desc, amount_brl),
-        "prev_bill_amount": Decimal("0"),
-        "interest_amount": Decimal("0"),
-        "amount_orig": Decimal("0.00"),
-        "currency_orig": "",
-        "amount_usd": Decimal("0.00"),
-    }
-    return row
 
 
 def build_regex_patterns() -> list[re.Pattern]:
@@ -417,6 +331,5 @@ __all__ = [
     "build_regex_patterns",
     "validate_date",
     "build_comprehensive_patterns",
-    "parse_statement_line",
     "ITAU_PARSING_RULES",
 ]

--- a/tests/test_parse_line.py
+++ b/tests/test_parse_line.py
@@ -4,9 +4,8 @@ import pytest
 from statement_refinery.txt_to_csv import parse_statement_line
 
 
-def _expected_hash(card: str, date: str, desc: str, amount: Decimal) -> str:
-    raw = f"{card}|{date}|{desc}|{amount}"
-    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+def _expected_hash(line: str) -> str:
+    return hashlib.sha1(line.encode()).hexdigest()
 
 
 def test_domestic_transaction():
@@ -14,22 +13,23 @@ def test_domestic_transaction():
     row = parse_statement_line(line)
     assert row is not None
     assert row["card_last4"] == "6853"
-    assert row["post_date"] == "28/09"
+    year = __import__('datetime').date.today().year
+    assert row["post_date"] == f"{year}-09-28"
     assert row["desc_raw"] == "FARMACIA SAO JOAO 01/04"
     assert row["amount_brl"] == Decimal("21.73")
     assert row["installment_seq"] == 1
     assert row["installment_tot"] == 4
     assert row["category"] == "FARMÁCIA"
     assert row["fx_rate"] == Decimal("0.00")
-    h = _expected_hash("6853", "28/09", "FARMACIA SAO JOAO 01/04", Decimal("21.73"))
-    assert row["ledger_hash"] == h
+    assert row["ledger_hash"] == _expected_hash(line)
 
 
 def test_fx_transaction():
     line = "10/04 SumUp *BOTISRL 7,90 56,12\nEUR 1,00 = 6,27 BRL Milano"
     row = parse_statement_line(line)
     assert row is not None
-    assert row["post_date"] == "10/04"
+    year = __import__('datetime').date.today().year
+    assert row["post_date"] == f"{year}-04-10"
     assert row["desc_raw"] == "SumUp *BOTISRL"
     assert row["amount_orig"] == Decimal("7.90")
     assert row["amount_brl"] == Decimal("56.12")
@@ -43,7 +43,7 @@ def test_payment_line():
     row = parse_statement_line(line)
     assert row is not None
     assert row["amount_brl"] == Decimal("-500.00")
-    assert row["category"] == "DIVERSOS"
+    assert row["category"] == "PAGAMENTO"
 
 
 def test_adjustment_line():


### PR DESCRIPTION
## Summary
- drop the outdated `parse_statement_line` implementation
- keep the ISO date version and import `date`
- clean up `__all__` and update tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f32236388327ab928d49b86953a1