### PR TITLE
Update README with editable install instruction before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ The `--out` option specifies where the CSV will be written. If omitted, the CSV 
 
 ## Running the Tests
 
-Execute the test suite with:
+Before running the test suite, install the package in editable mode with the
+development dependencies:
 
 ```bash
+pip install -e '.[dev]'
 pytest
 ```
 


### PR DESCRIPTION
## Summary
- update testing section in README with instructions to install in editable mode before running tests

## Testing
- `pip install -e '.[dev]'` *(fails: Could not find a version that satisfies the requirement setuptools>=65)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'statement_refinery')*

------
https://chatgpt.com/codex/tasks/task_e_6840f94db1448327bbea860c4608ecae