### PR TITLE
Remove ignore in parse_statement_line

### DIFF
--- a/src/statement_refinery/txt_to_csv.py
+++ b/src/statement_refinery/txt_to_csv.py
@@ -211,7 +211,7 @@ def _iso_date(date_str: str) -> str:
     return f"{yr}-{month.zfill(2)}-{day.zfill(2)}"
 
 
-def parse_statement_line(line: str) -> dict | None:  # type: ignore[no-redef]
+def parse_statement_line(line: str) -> dict | None:
     """Parse one statement line into a row dictionary.
 
     The parser is deliberately tolerant and handles domestic transactions,


### PR DESCRIPTION
## Summary
- delete unused type ignore from `parse_statement_line`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f9453a1c83278e06bccdab02b7ef