### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The `--out` option specifies where the CSV will be written. If omitted, the CSV 
 
 ## Running the Tests
 
-Before running the test suite, install the package in editable mode with the
-development dependencies:
+Before running the test suite, install the package in editable mode with its
+optional `dev` dependencies:
 
 ```bash
 pip install -e '.[dev]'


### PR DESCRIPTION
## Summary
- mention optional `dev` dependencies are required for running tests

## Testing
- `pip install -e '.[dev]'` *(fails: no matching distribution due to network restrictions)*
- `pytest` *(fails: ModuleNotFoundError: statement_refinery)*

------
https://chatgpt.com/codex/tasks/task_e_6840fcab5c3483279204cc3c4c03ecc1