### PR TITLE
Add pytest-cov optional dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "ruff",
     "black",
     "pytest",
+    "pytest-cov",
     "mypy",
 ]
 


### PR DESCRIPTION
## Summary
- enable coverage for CI by adding `pytest-cov` in optional dev dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'statement_refinery')*

------
https://chatgpt.com/codex/tasks/task_e_6840ff2f330c8327875abdf66628f2bd