### PR TITLE
Update README with installation troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ After cloning the repository, install the package in editable mode **with develo
 
     pip install -e '.[dev]'
 
+## Common Installation Issues
+
+The installation step fetches `pdfplumber` and its dependencies from PyPI.
+If your environment lacks internet access, this download will fail. In that
+case, pre-download the required wheels or install the package in an
+environment that can reach PyPI.
+
+Once installation succeeds, the CLI becomes available as `pdf-to-csv`. Run it
+with a PDF file to generate a CSV:
+
+    pdf-to-csv input.pdf --out output.csv
+
 ## Command-Line Usage
 
 Convert a PDF statement to CSV:


### PR DESCRIPTION
## Summary
- add a section covering installation issues
- show how to run the CLI after installing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684101ef0d4083278752246786926e83