### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Leonardo Lech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,4 +30,8 @@ The test suite depends on the package’s *development* extras. Install them and
 * **Zero-friction analysis** – clean CSVs ready for spreadsheets or BI tools.  
 * **Open by default** – contributions welcome; see `CONTRIBUTING.md` for guidelines.
 
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
 Happy refining!


### PR DESCRIPTION
## Summary
- add MIT License file
- document the license in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'statement_refinery')*

------
https://chatgpt.com/codex/tasks/task_e_684101ee2cb08327bf8fb8343609b828