### PR TITLE
Add pdfplumber check in test_pdf_to_csv

### DIFF
--- a/tests/test_pdf_to_csv.py
+++ b/tests/test_pdf_to_csv.py
@@ -5,6 +5,12 @@ Any new PDF + corresponding golden CSV added to tests/data/
 automatically becomes part of the test matrix.
 """
 
+import importlib
+import pytest
+
+if importlib.util.find_spec("pdfplumber") is None:
+    pytest.skip("pdfplumber not installed", allow_module_level=True)
+
 from pathlib import Path
 import filecmp
 import subprocess


### PR DESCRIPTION
## Summary
- skip PDF parsing tests if `pdfplumber` is not installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841058bcbf88327a79c7fb10c1af4dd