### PR TITLE
Lazy import pdfplumber in pdf_to_csv

### DIFF
--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Iterator, List
 import shutil
 
-import pdfplumber  # type: ignore  # pip install pdfplumber
 
 from . import txt_to_csv as t2c  # existing legacy parser
 
@@ -47,6 +46,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 # ───────────────────────── helpers ──────────────────────────
 def iter_pdf_lines(pdf_path: Path) -> Iterator[str]:
     """Yield each non-empty line of the PDF."""
+    import pdfplumber  # type: ignore  # moved inside the function
     with pdfplumber.open(str(pdf_path)) as pdf:
         for idx, page in enumerate(pdf.pages, 1):
             text = page.extract_text()


### PR DESCRIPTION
## Summary
- load `pdfplumber` inside `iter_pdf_lines` to avoid a hard dependency when golden CSVs exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410a181f408327b8da0efa8ba0cf95