### PR TITLE
Add openai to optional dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "mypy",
+    "openai",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- enable CI's auto-patch to load openai by adding it to dev optional dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410fc8e9ac8327b6cffc5381ccd7f3