### PR TITLE
Add stdout regression test

### DIFF
--- a/tests/test_pdf_cli.py
+++ b/tests/test_pdf_cli.py
@@ -67,3 +67,13 @@ def test_main_parse_pdf(tmp_path):
     lines = out_csv.read_text().splitlines()
     assert lines[0] == ";".join(mod.CSV_HEADER)
     assert len(lines) > 1
+
+
+def test_main_parse_pdf_stdout(tmp_path, capsys):
+    pdf_path = tmp_path / "copy.pdf"
+    pdf_path.write_bytes(PDF_SAMPLE.read_bytes())
+    mod.main([str(pdf_path)])
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    assert lines[0] == ";".join(mod.CSV_HEADER)
+    assert len(lines) > 1

--- a/tests/test_pdf_to_csv.py
+++ b/tests/test_pdf_to_csv.py
@@ -8,10 +8,7 @@ automatically becomes part of the test matrix.
 import importlib
 import pytest
 from pathlib import Path
-import filecmp
-import subprocess
-import sys
-import os
+from statement_refinery import pdf_to_csv as mod
 
 DATA = Path(__file__).parent / "data"
 PDFS = list(DATA.glob("*.pdf"))
@@ -25,31 +22,13 @@ if importlib.util.find_spec("pdfplumber") is None and missing_golden:
     )
 
 
-def run_parser(pdf_path: Path, out_path: Path) -> None:
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "statement_refinery.pdf_to_csv",
-            str(pdf_path),
-            "--out",
-            str(out_path),
-        ],
-        check=True,
-        env=env,
-    )
-
-
-def test_all_pdfs(tmp_path):
+def test_all_pdfs(capsys):
     assert PDFS, "No PDF samples found in tests/data/"
 
     for pdf in PDFS:
         golden = DATA / f"golden_{pdf.stem.split('_')[-1]}.csv"
         assert golden.exists(), f"Golden file missing for {pdf.name}"
 
-        out_csv = tmp_path / golden.name
-        run_parser(pdf, out_csv)
-
-        assert filecmp.cmp(out_csv, golden, shallow=False), f"Mismatch for {pdf.name}"
+        mod.main([str(pdf)])
+        captured = capsys.readouterr()
+        assert captured.out == golden.read_text(), f"Mismatch for {pdf.name}"


### PR DESCRIPTION
## Summary
- capture CLI output using `capsys` for regression tests
- check parsing to stdout when no golden CSV is present

## Testing
- `pytest -q`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_6841125651788327998a4db892936136