### PR TITLE
Apply Black formatting

### DIFF
--- a/src/statement_refinery/txt_to_csv.py
+++ b/src/statement_refinery/txt_to_csv.py
@@ -23,9 +23,7 @@ from datetime import date
 
 # Domestic transaction patterns
 RE_DOM_STRICT: Final = re.compile(
-    r"^(?P<date>\d{1,2}/\d{1,2})\s+"
-    r"(?P<desc>.+?)\s+"
-    r"(?P<amt>-?\d{1,3}(?:\.\d{3})*,\d{2})$"
+    r"^(?P<date>\d{1,2}/\d{1,2})\s+" r"(?P<desc>.+?)\s+" r"(?P<amt>-?\d{1,3}(?:\.\d{3})*,\d{2})$"
 )
 
 RE_DOM_TOLERANT: Final = re.compile(

--- a/tests/test_pdf_cli.py
+++ b/tests/test_pdf_cli.py
@@ -120,7 +120,8 @@ def test_iter_pdf_lines_skips_empty_page(monkeypatch, caplog):
     def dummy_open(_):
         return DummyPdf()
 
-    import types, sys
+    import types
+    import sys
 
     # Inject a dummy pdfplumber module with just an `open` function.
     dummy_module = types.SimpleNamespace(open=dummy_open)


### PR DESCRIPTION
## Summary
- format `tests/test_pdf_cli.py` and `src/statement_refinery/txt_to_csv.py` using Black with line length 100

## Testing
- `ruff check .`
- `mypy src/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684115dc39c88327a480ac19e815a6f7