### PR TITLE
Fix imports in pdf CLI test

### DIFF
--- a/tests/test_pdf_cli.py
+++ b/tests/test_pdf_cli.py
@@ -120,7 +120,8 @@ def test_iter_pdf_lines_skips_empty_page(monkeypatch, caplog):
     def dummy_open(_):
         return DummyPdf()
 
-    import types, sys
+    import types
+    import sys
 
     # Inject a dummy pdfplumber module with just an `open` function.
     dummy_module = types.SimpleNamespace(open=dummy_open)


### PR DESCRIPTION
## Summary
- split the combined `import types, sys` statement in `tests/test_pdf_cli.py`
- ensure file ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684115db63b08327948f4e0a0acf32ad