### PR TITLE
Derive statement year from PDF name

### DIFF
--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -183,13 +183,13 @@ def build_comprehensive_patterns():
     return patterns
 
 
-def _iso_date(date_str: str) -> str:
-    yr = date.today().year
+def _iso_date(date_str: str, year: int | None = None) -> str:
+    yr = year or date.today().year
     day, month = date_str.split("/")
     return f"{yr}-{month.zfill(2)}-{day.zfill(2)}"
 
 
-def parse_statement_line(line: str) -> dict | None:
+def parse_statement_line(line: str, year: int | None = None) -> dict | None:
     original_line = line
     line = line.strip()
     if not line:
@@ -220,7 +220,7 @@ def parse_statement_line(line: str) -> dict | None:
             category = "PAGAMENTO"
         return {
             "card_last4": card_last4,
-            "post_date": _iso_date(date_str),
+            "post_date": _iso_date(date_str, year),
             "desc_raw": desc,
             "amount_brl": amt_brl,
             "installment_seq": inst_seq or 0,
@@ -250,7 +250,7 @@ def parse_statement_line(line: str) -> dict | None:
             category = "PAGAMENTO"
         return {
             "card_last4": card_last4,
-            "post_date": _iso_date(date_str),
+            "post_date": _iso_date(date_str, year),
             "desc_raw": desc,
             "amount_brl": amt_brl,
             "installment_seq": inst_seq or 0,
@@ -355,12 +355,12 @@ def iter_pdf_lines(pdf_path: Path) -> Iterator[str]:
                     yield line
 
 
-def parse_lines(lines: Iterator[str]) -> List[dict]:
+def parse_lines(lines: Iterator[str], year: int | None = None) -> List[dict]:
     """Convert raw lines into row-dicts using :func:`parse_statement_line`."""
     rows: List[dict] = []
     for line in lines:
         try:
-            row = parse_statement_line(line)
+            row = parse_statement_line(line, year)
             if row:
                 rows.append(row)
         except Exception as exc:  # pragma: no cover
@@ -368,9 +368,9 @@ def parse_lines(lines: Iterator[str]) -> List[dict]:
     return rows
 
 
-def parse_pdf_from_golden(pdf_path: Path) -> List[dict]:
+def parse_pdf_from_golden(pdf_path: Path, year: int | None = None) -> List[dict]:
     """Parse the PDF and return the list of row dictionaries."""
-    return parse_lines(iter_pdf_lines(pdf_path))
+    return parse_lines(iter_pdf_lines(pdf_path), year)
 
 
 def write_csv(rows: List[dict], out_fh) -> None:
@@ -401,7 +401,14 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--out", type=Path, default=None, help="Output CSV path")
     args = parser.parse_args(argv)
 
-    golden = args.pdf.with_name(f"golden_{args.pdf.stem.split('_')[-1]}.csv")
+    stem_suffix = args.pdf.stem.split('_')[-1]
+    yr = None
+    try:
+        yr = int(stem_suffix.split('-')[0])
+    except (ValueError, IndexError):
+        yr = None
+
+    golden = args.pdf.with_name(f"golden_{stem_suffix}.csv")
     if golden.exists():
         if args.out:
             shutil.copyfile(golden, args.out)
@@ -410,7 +417,7 @@ def main(argv: list[str] | None = None) -> None:
             sys.stdout.write(golden.read_text(encoding="utf-8"))
         return
 
-    rows = parse_pdf_from_golden(args.pdf)
+    rows = parse_pdf_from_golden(args.pdf, yr)
     _LOGGER.info("Parsed %d transactions", len(rows))
 
     if args.out:

--- a/tests/test_pdf_cli.py
+++ b/tests/test_pdf_cli.py
@@ -131,3 +131,15 @@ def test_iter_pdf_lines_skips_empty_page(monkeypatch, caplog):
     lines = list(mod.iter_pdf_lines(Path("dummy.pdf")))
     assert lines == []
     assert "no extractable text" in caplog.text.lower()
+
+
+@pytest.mark.skipif(not HAS_PDFPLUMBER, reason="pdfplumber not installed")
+def test_main_infers_year(tmp_path):
+    pdf_src = DATA / "itau_2024-10.pdf"
+    pdf_path = tmp_path / "itau_2023-05.pdf"
+    pdf_path.write_bytes(pdf_src.read_bytes())
+    out_csv = tmp_path / "out.csv"
+    mod.main([str(pdf_path), "--out", str(out_csv)])
+    reader = csv.DictReader(out_csv.read_text().splitlines(), delimiter=";")
+    first = next(reader)
+    assert first["post_date"].startswith("2023-")


### PR DESCRIPTION
## Summary
- allow `_iso_date`, `parse_statement_line`, `parse_lines` and `parse_pdf_from_golden` to accept an optional `year`
- infer the statement year from the input PDF name in `main`
- test year inference by running `main` on a renamed PDF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411e8d40f48327b1007491dcb9ad18