### PR TITLE
Pin openai dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "mypy",
-    "openai",
+    "openai<1",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- pin the openai library to `<1` to keep compatibility with existing tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411f5349f48327b8c0a051b7015385