### PR TITLE
Rename parse_pdf_from_golden to parse_pdf

### DIFF
--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -309,7 +309,7 @@ __all__ = [
     "CSV_HEADER",
     "iter_pdf_lines",
     "parse_lines",
-    "parse_pdf_from_golden",
+    "parse_pdf",
     "write_csv",
     "main",
 ]
@@ -368,7 +368,7 @@ def parse_lines(lines: Iterator[str]) -> List[dict]:
     return rows
 
 
-def parse_pdf_from_golden(pdf_path: Path) -> List[dict]:
+def parse_pdf(pdf_path: Path) -> List[dict]:
     """Parse the PDF and return the list of row dictionaries."""
     return parse_lines(iter_pdf_lines(pdf_path))
 
@@ -410,7 +410,7 @@ def main(argv: list[str] | None = None) -> None:
             sys.stdout.write(golden.read_text(encoding="utf-8"))
         return
 
-    rows = parse_pdf_from_golden(args.pdf)
+    rows = parse_pdf(args.pdf)
     _LOGGER.info("Parsed %d transactions", len(rows))
 
     if args.out:


### PR DESCRIPTION
## Summary
- rename `parse_pdf_from_golden` to `parse_pdf`
- use the new name in the CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411e9798c083278774fe464ca546be