### PR TITLE
Fix evolve tool to work with OpenAI <1

### DIFF
--- a/.github/tools/evolve.py
+++ b/.github/tools/evolve.py
@@ -89,7 +89,7 @@ TOKENS_USED = 0
 
 def generate_patch(fail_log: str) -> str:
     global TOKENS_USED
-    resp = openai.chat.completions.create(
+    resp = openai.ChatCompletion.create(
         model=MODEL,
         messages=[
             {


### PR DESCRIPTION
## Summary
- ensure `.github/tools/evolve.py` uses the legacy `ChatCompletion.create` method

## Testing
- `ruff check .`
- `black --check .`
- `mypy src`
- `pytest -ra -vv --cov=statement_refinery --cov-report=term-missing --cov-fail-under=90` *(fails: test_edge_case_parsing, test_evolution_trigger)*
- `python .github/tools/evolve.py` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68412cf77c188327ace8154eb2b83e50