### PR TITLE
Remove stray README line

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,3 @@ python .github/tools/evolve.py
 This project is licensed under the [MIT License](LICENSE).
 
 Happy refining!
-# Trigger evolution after API key setup


### PR DESCRIPTION
## Summary
- delete leftover trigger line from README

## Testing
- `pytest` *(fails: SPECIAL_MERCHANT_CATEGORY assertion)*

------
https://chatgpt.com/codex/tasks/task_e_684133efcd6483279c25b7720153a71e