### PR TITLE
Improve openai key checks

### DIFF
--- a/.github/tools/codex_patch.py
+++ b/.github/tools/codex_patch.py
@@ -11,8 +11,14 @@ import subprocess
 import tempfile
 from pathlib import Path
 import openai
+import sys
 
-openai.api_key = os.environ["OPENAI_API_KEY"]
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    print("Missing OPENAI_API_KEY environment variable.", file=sys.stderr)
+    raise SystemExit(1)
+
+client = openai.OpenAI(api_key=api_key)
 MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
 
 
@@ -22,7 +28,7 @@ def sh(*cmd):
 
 def main():
     print("⚙️  Generating single Codex patch…")
-    resp = openai.ChatCompletion.create(
+    resp = client.chat.completions.create(
         model=MODEL,
         messages=[
             {

--- a/.github/tools/evolve.py
+++ b/.github/tools/evolve.py
@@ -26,11 +26,18 @@ from pathlib import Path
 from typing import Tuple
 
 import openai
+import sys
 
 ROOT = Path(__file__).resolve().parents[2]  # repo root
 BEST_BRANCH = "codex/best"
 SCORE_FILE = ROOT / ".github/tools/score_best.json"
-client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    print("Missing OPENAI_API_KEY environment variable.", file=sys.stderr)
+    raise SystemExit(1)
+
+client = openai.OpenAI(api_key=api_key)
 MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
 MAX_ATTEMPTS = int(os.getenv("MAX_ATTEMPTS", "3"))
 MAX_TOKENS = int(os.getenv("MAX_TOKENS_PER_RUN", "1000000"))


### PR DESCRIPTION
## Summary
- check OPENAI_API_KEY before instantiating OpenAI client in evolve.py
- apply the same check in codex_patch.py and use client

## Testing
- `pytest -q` *(fails: tests/test_txt_to_csv.py::test_demo_evolution)*

------
https://chatgpt.com/codex/tasks/task_e_684135cada048327aafbc51e661c72d6