### PR TITLE
Handle missing openai

### DIFF
--- a/.github/tools/codex_patch.py
+++ b/.github/tools/codex_patch.py
@@ -10,8 +10,16 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-import openai
 import sys
+
+try:
+    import openai
+except ImportError:
+    print(
+        "The openai package is required. Install with `pip install openai`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 api_key = os.getenv("OPENAI_API_KEY")
 if not api_key:

--- a/.github/tools/evolve.py
+++ b/.github/tools/evolve.py
@@ -24,9 +24,16 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Tuple
-
-import openai
 import sys
+
+try:
+    import openai
+except ImportError:
+    print(
+        "The openai package is required. Install with `pip install openai`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 ROOT = Path(__file__).resolve().parents[2]  # repo root
 BEST_BRANCH = "codex/best"


### PR DESCRIPTION
## Summary
- catch missing `openai` dependency in evolve helper scripts

## Testing
- `pytest -q` *(fails: test_local_evolution_demo)*

------
https://chatgpt.com/codex/tasks/task_e_6841396910d88327b29d9310a748ffee