### PR TITLE
Update CI to allow manual patch loop

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,9 +59,9 @@ jobs:
         continue-on-error: true
         run: pytest -ra -vv --cov=statement_refinery --cov-report=term-missing --cov-fail-under=90
 
-      # auto-patch loop if tests failed
+      # auto-patch loop if tests failed or FORCE_EVOLVE=1
       - name: Evolve patch loop
-        if: steps.tests.outcome == 'failure'
+        if: steps.tests.outcome == 'failure' || env.FORCE_EVOLVE == '1'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ export OPENAI_API_KEY=your-key
 python .github/tools/evolve.py
 ```
 
+Set `FORCE_EVOLVE=1` to force the loop to run even when the first test pass
+is successful. This can be handy when experimenting locally or when
+triggering the workflow manually in CI.
+
 ## Project Goals
 
 * **Accuracy first** – robust regex rules tuned for Itaú PDFs.  


### PR DESCRIPTION
## Summary
- allow the `Evolve patch loop` step to run even if tests pass when `FORCE_EVOLVE=1`
- document the new environment variable in the workflow comments and README

## Testing
- `pytest -q` *(fails: test_local_evolution_demo)*

------
https://chatgpt.com/codex/tasks/task_e_68413968448083278d14a40f771e17eb