### PR TITLE
Fix invalid date handling

### DIFF
--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -184,6 +184,24 @@ def build_comprehensive_patterns():
 
 
 def _iso_date(date_str: str, year: int | None = None) -> str:
+    """Return ISO formatted date string from ``DD/MM`` format.
+
+    Parameters
+    ----------
+    date_str:
+        Date string in ``DD/MM`` format.
+    year:
+        Year for the resulting date. Defaults to the current year.
+
+    Raises
+    ------
+    ValueError
+        If ``date_str`` does not represent a valid day and month.
+    """
+
+    if not validate_date(date_str):
+        raise ValueError(f"Invalid date: {date_str}")
+
     yr = year or date.today().year
     day, month = date_str.split("/")
     return f"{yr}-{month.zfill(2)}-{day.zfill(2)}"
@@ -227,9 +245,13 @@ def parse_statement_line(line: str, year: int | None = None) -> dict | None:
         category = classify_transaction(desc, amt_brl)
         if RE_PAYMENT.search(line):
             category = "PAGAMENTO"
+        try:
+            post_date = _iso_date(date_str, year)
+        except ValueError:
+            return None
         return {
             "card_last4": card_last4,
-            "post_date": _iso_date(date_str, year),
+            "post_date": post_date,
             "desc_raw": desc,
             "amount_brl": amt_brl,
             "installment_seq": inst_seq or 0,
@@ -259,9 +281,13 @@ def parse_statement_line(line: str, year: int | None = None) -> dict | None:
         category = classify_transaction(desc, amt_brl)
         if RE_PAYMENT.search(line_no_card):
             category = "PAGAMENTO"
+        try:
+            post_date = _iso_date(date_str, year)
+        except ValueError:
+            return None
         return {
             "card_last4": card_last4,
-            "post_date": _iso_date(date_str, year),
+            "post_date": post_date,
             "desc_raw": desc,
             "amount_brl": amt_brl,
             "installment_seq": inst_seq or 0,

--- a/tests/test_parse_line.py
+++ b/tests/test_parse_line.py
@@ -75,6 +75,16 @@ def test_invalid_day_skipped():
     assert parse_statement_line(line) is None
 
 
+def test_invalid_month_overflow_skipped():
+    line = "05/13 SOME TEXT 1,00"
+    assert parse_statement_line(line) is None
+
+
+def test_invalid_day_zero_skipped():
+    line = "00/12 SOME TEXT 1,00"
+    assert parse_statement_line(line) is None
+
+
 def test_header_fragment_skipped():
     line = "R$    R$"
     assert parse_statement_line(line) is None


### PR DESCRIPTION
## Summary
- guard `_iso_date` and skip invalid dates
- extend unit tests for malformed date lines

## Testing
- `pytest tests/test_parse_line.py::test_invalid_month_overflow_skipped tests/test_parse_line.py::test_invalid_day_zero_skipped -q`
- `pytest -q` *(fails: test_local_evolution_demo, test_all_statements)*

------
https://chatgpt.com/codex/tasks/task_e_6841a71fef048327a1b2b1ca9b887f32