### PR TITLE
Update parser accuracy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Run `scripts/check_accuracy.py` to compare the parser output with any golden fil
 
 The tool runs `pdf_to_csv.main()` for each PDF in `tests/data/` and reports diffs and a match percentage.
 
+Only PDFs that have a companion `golden_*.csv` file are included in the diff. Any
+others are skipped. Store diagnostic statements outside the repository or place
+them in `tests/data/` alongside a matching golden CSV if you want them checked
+in CI.
+
 This check also runs in CI after the tests. If any mismatch is detected the job
 fails. Update the golden CSV by rerunning `pdf-to-csv` with the `--out` option
 (for example `pdf-to-csv tests/data/itau_2024-10.pdf --out tests/data/golden_2024-10.csv`) and commit


### PR DESCRIPTION
## Summary
- document that only PDFs with `golden_*.csv` are checked
- explain where to store diagnostic PDFs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a9ea10188327b460ac41cbde3ace