### PR TITLE
Handle missing pdfplumber for validation tests

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,14 @@
+import importlib.util
+import pytest
 import re
 from decimal import Decimal
 from pathlib import Path
-import pdfplumber
+
+if importlib.util.find_spec("pdfplumber") is None:
+    pytest.skip("pdfplumber not installed", allow_module_level=True)
+else:
+    import pdfplumber
+
 from statement_refinery.pdf_to_csv import parse_pdf
 
 


### PR DESCRIPTION
## Summary
- add a check for `pdfplumber` at the top of `tests/test_validation.py`
- skip tests when `pdfplumber` is not installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a9f12e488327b20afe32eeda8f6b