### PR TITLE
Improve portability of accuracy check script

### DIFF
--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -2,11 +2,13 @@ import io
 import contextlib
 from pathlib import Path
 import difflib
-
-from statement_refinery import pdf_to_csv
-
+import sys, os  # noqa: E401,F401
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from statement_refinery import pdf_to_csv  # noqa: E402
+
 DATA_DIR = ROOT / "tests" / "data"
 
 


### PR DESCRIPTION
## Summary
- ensure `scripts/check_accuracy.py` can run without installing the package

## Testing
- `ruff check .`
- `black --check .`
- `mypy src`
- `pytest -q`
- `python scripts/check_accuracy.py`

------
https://chatgpt.com/codex/tasks/task_e_6841acaf60fc8327a9b9c4edb6f824bb