### PR TITLE
Update docs for diagnostics handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Run `scripts/check_accuracy.py` to compare the parser output with any golden fil
 The tool runs `pdf_to_csv.main()` for each PDF in `tests/data/` and reports diffs and a match percentage.
 
 Only PDFs that have a companion `golden_*.csv` file are included in the diff. Any
-others are skipped. Store diagnostic statements outside the repository or place
-them in `tests/data/` alongside a matching golden CSV if you want them checked
-in CI.
+others are skipped. **Store new PDFs without goldens outside the repository or under
+the ignored `diagnostics/` folder.** Place them in `tests/data/` alongside a matching
+golden CSV if you want them checked in CI.
 
 This check also runs in CI after the tests. If any mismatch is detected the job
 fails. Update the golden CSV by rerunning `pdf-to-csv` with the `--out` option

--- a/tests/test_pdf_to_csv.py
+++ b/tests/test_pdf_to_csv.py
@@ -11,15 +11,12 @@ from pathlib import Path
 from statement_refinery import pdf_to_csv as mod
 
 DATA = Path(__file__).parent / "data"
-PDFS = list(DATA.glob("*.pdf"))
-missing_golden = [
-    pdf for pdf in PDFS if not (DATA / f"golden_{pdf.stem.split('_')[-1]}.csv").exists()
+# Only test PDFs that have corresponding golden CSVs
+PDFS = [
+    pdf
+    for pdf in DATA.glob("*.pdf")
+    if (DATA / f"golden_{pdf.stem.split('_')[-1]}.csv").exists()
 ]
-if importlib.util.find_spec("pdfplumber") is None and missing_golden:
-    pytest.skip(
-        "pdfplumber not installed and no golden CSV for every PDF",
-        allow_module_level=True,
-    )
 
 
 def test_all_pdfs(capsys):


### PR DESCRIPTION
## Summary
- clarify how to store PDFs that lack golden CSVs
- tighten PDF regression test matrix to files that have goldens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ced41cf48327b2be03dd0a6e123b