### PR TITLE
Update README about offline openai package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The installation step fetches `pdfplumber` and its dependencies from PyPI.
 If your environment lacks internet access, this download will fail. In that
 case, pre-download the required wheels or install the package in an
 environment that can reach PyPI.
+The `openai` package, installed via `pip install -e '.[dev]'`, must also be
+available offline for the evolution script.
 
 `pdfplumber` is only needed when parsing PDFs that do not yet have a
 corresponding golden CSV. The tests and operations that use those golden files


### PR DESCRIPTION
## Summary
- mention `openai` package must be available offline in Common Installation Issues

## Testing
- `pytest -q` *(fails: AssertionError in test_all_statements)*

------
https://chatgpt.com/codex/tasks/task_e_6841d1f85a608327a9522a695b5fb845