### PR TITLE
Remove unused imports from pdf_to_csv test

### DIFF
--- a/tests/test_pdf_to_csv.py
+++ b/tests/test_pdf_to_csv.py
@@ -5,8 +5,6 @@ Any new PDF + corresponding golden CSV added to tests/data/
 automatically becomes part of the test matrix.
 """
 
-import importlib
-import pytest
 from pathlib import Path
 from statement_refinery import pdf_to_csv as mod
 


### PR DESCRIPTION
## Summary
- drop unused `importlib` and `pytest` imports from `tests/test_pdf_to_csv.py`

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6841d45f879c8327a4ab1287218111ed