### PR TITLE
Enable CI self-healing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ env:
 jobs:
   static:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
     steps:
       - uses: actions/checkout@v4
 
@@ -41,6 +44,9 @@ jobs:
   tests-evolve:
     needs: static
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +70,7 @@ jobs:
         if: steps.tests.outcome == 'failure' || env.FORCE_EVOLVE == '1'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
         run: python .github/tools/evolve.py
 
       # confirm everything green after patch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,14 @@ dependencies = [
 [project.scripts]
 pdf-to-csv = "statement_refinery.pdf_to_csv:main"
 
-[project.optional-dependencies]
+[project.optional-dependencies.dev]
 # Development dependencies for linting, type checking and tests
-dev = [
-    "ruff",
-    "black",
-    "pytest",
-    "pytest-cov",
-    "mypy",
-    "openai>=1.0",
-]
+ruff = "*"
+black = "*"
+pytest = "*"
+pytest-cov = "*"
+mypy = "*"
+openai = "*"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary
- expose OPENAI and PAT tokens to CI jobs
- use the personal access token in the evolve step
- manage dev dependencies through the optional-dev table

## Testing
- `pip install -e '.[dev]'` *(fails: Could not find a version that satisfies the requirement setuptools>=65)*
- `pytest -q` *(fails: 1 failed, 30 passed)*
- `ruff check .` *(fails: Found 1 error)*
- `black --check .` *(fails: would reformat 2 files)*
- `mypy src/`

------
https://chatgpt.com/codex/tasks/task_e_6841d757c8b08327bf202f27c1ac5148