### PR TITLE
Update README with CI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ environment that can reach PyPI.
 The `openai` package, installed via `pip install -e '.[dev]'`, must also be
 available offline for the evolution script.
 
-`pdfplumber` is only needed when parsing PDFs that do not yet have a
-corresponding golden CSV. The tests and operations that use those golden files
-work even if `pdfplumber` is missing.
+`pdfplumber` is only strictly required when parsing PDFs that do not yet have a
+corresponding golden CSV. The tests and operations that use those goldens work
+without it, but installing the library is recommended so that the entire test
+suite can run without skips.
 
 Once installation succeeds, the CLI becomes available as `pdf-to-csv`. Run it
 with a PDF file to generate a CSV:
@@ -39,13 +40,19 @@ Convert a PDF statement to CSV:
 
 ## Running the Tests
 
-The test suite depends on the package’s *development* extras, which also install `openai` for the Codex tools. Install them and run:
+The test suite depends on the package’s *development* extras, which also
+install `openai` for the Codex tools. After installing the extras run the
+linters, type checker and the tests with coverage:
 
     pip install -e '.[dev]'
-    pytest
+    ruff check .
+    black --check .
+    mypy src/
+    pytest -ra -vv --cov=statement_refinery --cov-report=term-missing --cov-fail-under=90
 
-These tests rely on the checked-in golden CSV files and therefore do not
-require `pdfplumber` unless you add new PDFs.
+These tests rely on the checked-in golden CSV files, so `pdfplumber` is optional
+but recommended for full coverage. When it is missing the tests that parse PDFs
+will be skipped.
 
 During test runs the parser writes debug information to the `diagnostics/`
 directory. This folder is ignored by Git so feel free to inspect or delete any
@@ -84,6 +91,15 @@ python scripts/analyze_pdfs.py ~/Downloads --write-csv
 ```
 
 These diagnostics operate solely on the PDFs, so no golden CSV is required.
+
+
+## CI Overview
+
+The GitHub Actions workflow runs on every push, pull request and once daily at
+03:00 UTC via cron. It installs the development extras and then executes
+`ruff`, `black`, `mypy` and the test suite with coverage. Coverage must remain
+above **90%** or the run fails. When any test fails the job invokes the AI
+patch loop described below to automatically attempt fixes.
 
 
 ## Auto-Patch Loop

--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import difflib
 import importlib.util
 import sys, os  # noqa: E401,F401
-import importlib.util
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))


### PR DESCRIPTION
## Summary
- describe optional use of `pdfplumber`
- detail ruff/black/mypy in the testing section and note coverage
- document scheduled CI run and the auto-patch loop
- fix duplicate import in `scripts/check_accuracy.py`

## Testing
- `ruff check .`
- `black --check .`
- `mypy src/` *(fails: Cannot find implementation or library stub for module named "pdfplumber")*
- `pytest -ra -vv --cov=statement_refinery --cov-report=term-missing --cov-fail-under=90` *(fails: Coverage failure: total of 68 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_6841e776ff488327a0c278addee45053