### PR TITLE
Configure bot PAT for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,14 @@ env:
   MAX_TOKENS_PER_RUN: '1000000'   # 1 M-token budget
   MAX_ATTEMPTS: '3'
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
+  GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
 
 jobs:
   static:
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
+      GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
+      GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
     steps:
       - uses: actions/checkout@v4
 
@@ -72,7 +72,7 @@ jobs:
         if: steps.tests.outcome == 'failure' || env.FORCE_EVOLVE == '1'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN:   ${{ secrets.PERSONAL_ACCESS_TOKEN_CLASSIC }}
+          GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
 
         run: python .github/tools/evolve.py
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Set `FORCE_EVOLVE=1` to force the loop to run even when the first test pass
 is successful. This can be handy when experimenting locally or when
 triggering the workflow manually in CI.
 
+## Required Secret Scopes
+
+The CI workflow expects a `BOT_PAT` secret containing a personal access token
+for the GitHub bot account. The token only needs to push commits and open pull
+requests in this repository. Grant the minimal permissions by enabling
+`contents:write` and `pull_requests:write` (or the classic `repo` scope).
+
 ## Project Goals
 
 * **Accuracy first** – robust regex rules tuned for Itaú PDFs.  


### PR DESCRIPTION
## Summary
- reference a `BOT_PAT` secret in CI
- document required bot token scopes in README

## Testing
- `ruff check .` *(fails: F811 redefinition error)*
- `black --check .` *(fails: would reformat two files)*
- `mypy src/`
- `pytest -ra -vv` *(fails: tests/test_validation.py::test_all_statements)*

------
https://chatgpt.com/codex/tasks/task_e_6841e771d0308327b6aacfe079ceb01f