### PR TITLE
Fix duplicate import and update formatting config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ After cloning the repository, install the package in editable mode **with develo
 
     pip install -e '.[dev]'
 
+You can run the same formatting and lint checks as the CI pipeline using
+`pre-commit`:
+
+    pre-commit run --files <path/to/file.py>
+
 ## Common Installation Issues
 
 The installation step fetches `pdfplumber` and its dependencies from PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,11 @@ dev = [
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = ["statement_refinery"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.black]
+target-version = ["py312"]
+line-length = 88

--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import difflib
 import importlib.util
 import sys, os  # noqa: E401,F401
-import importlib.util
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))

--- a/src/statement_refinery/pdf_to_csv.py
+++ b/src/statement_refinery/pdf_to_csv.py
@@ -96,18 +96,18 @@ RE_INTERNATIONAL_PATTERNS = [
 def parse_amount(amount_str: str) -> Decimal:
     """Parse Brazilian currency format to Decimal."""
     # Remove any currency symbols and extra spaces
-    clean = amount_str.replace('R$', '').strip()
+    clean = amount_str.replace("R$", "").strip()
     # Remove any characters except digits, comma, period, and minus sign
-    clean = re.sub(r'[^\d,\.\-]', '', clean)
+    clean = re.sub(r"[^\d,\.\-]", "", clean)
     # Handle different number formats
-    if ',' in clean and '.' in clean:
+    if "," in clean and "." in clean:
         # Brazilian format (1.234,56)
-        clean = clean.replace('.', '').replace(',', '.')
-    elif ',' in clean and '.' not in clean:
+        clean = clean.replace(".", "").replace(",", ".")
+    elif "," in clean and "." not in clean:
         # European/Brazilian format without thousands separator
-        clean = clean.replace(',', '.')
+        clean = clean.replace(",", ".")
     # Remove any trailing/leading dots
-    clean = clean.strip('.')
+    clean = clean.strip(".")
     return Decimal(clean)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -33,7 +33,7 @@ def extract_total_from_pdf(pdf_path: Path) -> Decimal:
             r"= Total desta fatura\s*[=R\$\s]*([\d\.]+,\d{2})",
             r"TOTAL\s*[=R\$\s]*([\d\.]+,\d{2})",
             r"Valor Total\s*[=R\$\s]*([\d\.]+,\d{2})",
-            r"Saldo Total\s*[=R\$\s]*([\d\.]+,\d{2})"
+            r"Saldo Total\s*[=R\$\s]*([\d\.]+,\d{2})",
         ]
 
         for pattern in patterns:


### PR DESCRIPTION
## Summary
- remove duplicate import from check_accuracy.py
- format pdf_to_csv.py and test_validation.py with Black
- configure Ruff and Black in pyproject.toml
- document running pre-commit in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy src/`
- `pytest -q` *(fails: AssertionError in test_all_statements)*
- `python scripts/check_accuracy.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e76cab58832796b30363fd3d40e7