### PR TITLE
Add text snapshots & fallback parsing

### DIFF
--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -26,6 +26,10 @@ def compare(pdf_path: Path) -> bool:
     with contextlib.redirect_stdout(buf):
         if HAS_PDFPLUMBER:
             pdf_to_csv.main([str(pdf_path)])
+            txt_file = pdf_path.with_suffix(".txt")
+            if not txt_file.exists():
+                lines = list(pdf_to_csv.iter_pdf_lines(pdf_path))
+                txt_file.write_text("\n".join(lines))
         else:
             txt = pdf_path.with_suffix(".txt")
             if not txt.exists():

--- a/tests/data/Itau_2024-07.txt
+++ b/tests/data/Itau_2024-07.txt
@@ -1,0 +1,251 @@
+A992500005B
+PC -00
+LEONARDO BROCKSTEDT LECH
+Resumo da fatura em R$
+DOLOMITI 781
+101 - Planalto Total da fatura anterior 5.731,86
+37607600
+99250-000 Serafina Correa - RS
+Pagamento efetuado em 19/06/2024 - 5.731,86
+"l)f#!
+S Saldo financiado 0,00
+Postagem: 03/07/2024 +
+E Encargos (financiamento + moratório) 333,02
+Vencimento: 10/07/2024 +
+L Lançamentos atuais 22.191,20
+Emissão: 02/07/2024
+030724 Previsão prox. Fechamento: 02/08/2024 = Total desta fatura 22.524,22
+Titular LEONARDO BROCKSTEDT LECH
+Cartão 5234.XXXX.XXXX.6853 MASTERCARD BLACK
+O total da sua fatura é: Com vencimento em: Limite total de crédito:
+R$ 22.524,22 10/07/2024 Flexível
+Preparamos outras opçõesdepagamento abaixo eaofinal dafatura, válidas atéadatadevencimento:
+Pagamento mínimo: Parcelas fixas:
+R$ 3.679,97 R$2.690,44
++ 10x R$ 2.690,44
+Valor em reais % do total financiado Valor em reais % do total financiado
+Valor total financiado R$ 18.844,25 100,00% Valor total financiado R$ 22.912,75 100,00%
+Encargos R$ 1.944,73 - Valor solicitado R$ 22.524,22 98,30 %
+IOF R$ 141,00 - IOF R$ 388,53 1,70 %
+Total a pagar R$ 24.609,95 - Total a pagar R$ 29.594,84 -
+Juros: 10,32 % am - 230,34 % aa CET: 10,95 % am - 253,88 % aa Juros: 5,45 % am - 90,72 % aa CET: 6,36 % am - 111,74 % aa
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 000 recibo do pagador
+Número do Documento 00406694061/0123903 Nosso Número 175/06694061-0
+Nome do Pagador/CPF/CNPJ LEONARDO BROCKSTEDT LECH - 024.244.030-40 Valor do Documento R$ 22.524,22
+Nome do Beneficiário/CPF/CNPJ ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23 Vencimento 10/07/2024
+Endereço do Beneficiário PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP Autenticação Mecânica
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 000
+Local de Pagamento Data de Vencimento
+Pague sua fatura em qualquer banco, mesmo após a data de vencimento. Dê preferência para o pagamento até a data de vencimento
+para não gerar encargos e/ou rescisão contratual. Em caso de atraso, os encargos serão cobrados na próxima fatura. 10/07/2024
+Nome do Beneficiário/ CNPJ/CPF/Endereço Agência / Código Beneficiário
+ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23
+PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP 2525/04345-7
+Data do Documento Número do Documento Espécie DOC. Aceite Data do Processamento Nosso Número
+10/07/2024 00406694061/0123903 FT N 02/07/2024 175/06694061-0
+Uso do Banco Carteira Espécie Quantidade Valor (=) Valor do Documento
+5/0 R$ R$ 22.524,22
+Instruções de responsabilidade do beneficiário. (-) Descontos / Abatimentos
+Indique o valor que deseja pagar no campo "Valor Pago". Dê preferência ao pagamento total. Não sendo possível, você terá as seguintes
+opções: (i) pagar quantia a partir do valor constante em Pagamento Mínimo , financiando o restante pelo crédito rotativo; (ii) optar por (+) Juros / Multa
+uma das opções de Parcelas Fixas , pagando o valor exato da parcela até a data do vencimento. O não pagamento poderá gerar
+inscrição nos órgãos restritivos de crédito. (=) Valor Pago
+Nome do Pagador/CPF/CNPJ/Endereço/Cidade/UF/CEP
+LEONARDO BROCKSTEDT LECH - 024.244.030-40
+<wwNnDNwONnNLwOnnWMNwITnnWI W7n8nn1W W- n1nnW0W1n n-nW PWlannnnWaWlntnnoW W- n9Nn9ww2N5Nn0Nw-w0nN0W0w n nSWewNrnannWfiNnwaNw CwnNonNrwrweNawN -w nRNwSnW -NnNNwnwNnWnwnnNWwnnWWn>
+Sacador Avalista:
+Autenticação Mecânica - Ficha de Compensação
+Caso você pague um valor entre o mínimo e o total de sua fatura, o saldo restante será cobrado na próxima fatura com juros e impostos. O pagamento
+do valor total é sempre a melhor opção porque não há cobranças de juros.
+O pagamento obrigatório é composto pelo saldo do crédito rotativo e respectivos encargos incidentes no período (R$ 354,49), prestações referentes a
+parcelamentos do saldo devedor de períodos anteriores (R$ 0,00) e valor mínimo de novas transações (R$ 3.325,48). Para entender mais sobre o
+pagamento obrigatório e o pagamento mínimo, acesse seu contrato e a aba "Serviços" no site Itaú Cartões.
+Consulte outras opções de parcelamento no final da sua fatura.
+Previsão do próximo fechamento: 02/08/2024.
+Lançamentos: compras e saques Lançamentos: compras e saques
+LEONARDO B LECH (final 6853) 10/06 RECARGAPAY 2.077,80
+DATA ESTABELECIMENTO VALOR EM R$ DIVERSOS .SAO PAULO
+29/02 7032 IGUATEMI POR05/05 248,90 16/06 APPLE.COM/BILL 49,90
+VESTUÁRIO .PORTO ALEGRE HOBBY .SAO PAULO
+08/05 GRIFE NATURAL 02/03 97,12 16/06 RECARGAPAY *LEONA01/12 18,28
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .
+28/05 FARMACIA SAO JOAO 02/06 39,40 16/06 RECARGAPAY *LEONA01/12 11,08
+SAÚDE .CAXIAS DO SUL DIVERSOS .
+28/05 FARMACIA SAO JOAO - 0,10 16/06 RECARGAPAY *LEONA01/12 40,44
+SAÚDE .CAXIAS DO SUL DIVERSOS .
+05/06 REFUGIO SKATE PARK LTD 66,00 16/06 RECARGAPAY *LEONA01/12 12,74
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .
+08/06 FARMACIA SAO JOAO 127,40 16/06 RECARGAPAY *LEONA01/12 20,50
+SAÚDE .PASSO FUNDO DIVERSOS .
+10/06 FARMACIA SAO JOAO 01/06 87,64 16/06 RECARGAPAY *LEONA01/12 21,61
+SAÚDE . DIVERSOS .
+10/06 POSTO TRADICAO 293,15 16/06 RECARGAPAY *LEONA01/12 60,94
+VEÍCULOS .PASSO FUNDO DIVERSOS .
+Lançamentos no cartão (final 6853) 959,51 16/06 RECARGAPAY *LEONA01/12 13,30
+DIVERSOS .
+LEONARDO B LECH (final 9779) 16/06 RECARGAPAY *LEONA01/12 14,96
+DATA ESTABELECIMENTO VALOR EM R$ DIVERSOS .
+04/06 SUPERFORCE PASSO FUND 297,00 16/06 RECARGAPAY *LEONA01/12 11,63
+HOBBY .PASSO FUNDO DIVERSOS .
+04/06 EBN *CANVA 34,90 Lançamentos no cartão (final 9779) 18.308,48
+DIVERSOS .CURITIBA
+10/06 NETFLIX.COM 39,90 LEONARDO B LECH (final 9931)
+DIVERSOS .SAO PAULO DATA ESTABELECIMENTO VALOR EM R$
+10/06 RECARGAPAY *LEONARDOB 5.194,50 27/09 PG *UNFAIR ACADEMY10/10 34,16
+DIVERSOS .SAO PAULO EDUCAÇÃO .FLORIANOPOLIS
+10/06 RECARGAPAY 5.194,50 27/09 PG *UNFAIR ACADEMY10/10 80,16
+DIVERSOS .SAO PAULO EDUCAÇÃO .FLORIANOPOLIS
+10/06 RECARGAPAY 5.194,50 Lançamentos no cartão (final 9931) 114,32
+DIVERSOS .SAO PAULO
+Continua...
+3003 3030
+0800 720 3030
+PC - 00 01290 VK045 03/07/2024 VKRPOF01 G4143 0670673
+Lançamentos: compras e saques Lançamentos: produtos e serviços
+LEONARDO B LECH (final 9835) Lançamentos produtos e serviços 21,47
+DATA ESTABELECIMENTO VALOR EM R$
+17/06 PICPAY LBL INTEGRA01/12 11,59
+DIVERSOS . L Total dos lançamentos atuais 22.191,20
+17/06 PICPAY LBL INTEGRA01/12 46,13
+DIVERSOS .
+Compras parceladas - próximas faturas
+17/06 PICPAY LBL INTEGRA01/05 107,60
+DIVERSOS . DATA ESTABELECIMENTO VALOR EM R$
+17/06 PICPAY LBL INTEGRA01/06 20,39 08/05 GRIFE NATURAL 03/03 97,12
+28/05 FARMACIA SAO JOAO 03/06 39,40
+DIVERSOS .
+18/06 PICPAY LBL INTEGRA01/06 30,53 10/06 FARMACIA SAO JOAO 02/06 87,64
+16/06 RECARGAPAY *LEONA02/12 18,28
+DIVERSOS .
+18/06 PICPAY LBL INTEGRA01/06 57,01 16/06 RECARGAPAY *LEONA02/12 11,08
+16/06 RECARGAPAY *LEONA02/12 40,44
+DIVERSOS .
+18/06 PICPAY LBL INTEGRA01/06 65,15 16/06 RECARGAPAY *LEONA02/12 12,74
+16/06 RECARGAPAY *LEONA02/12 20,50
+DIVERSOS .
+16/06 RECARGAPAY *LEONA02/12 21,61
+Lançamentos no cartão (final 9835) 338,40
+16/06 RECARGAPAY *LEONA02/12 60,94
+16/06 RECARGAPAY *LEONA02/12 13,30
+Lançamentos internacionais
+16/06 RECARGAPAY *LEONA02/12 14,96
+LEONARDO B LECH (final 6853) 16/06 RECARGAPAY *LEONA02/12 11,63
+DATA ESTABELECIMENTO US$ R$ 17/06 PICPAY LBL INTEGRA02/12 11,59
+17/06 binance.com 127,10 17/06 PICPAY LBL INTEGRA02/12 46,13
+Vilnius 120,00 BRL 22,22 17/06 PICPAY LBL INTEGRA02/05 107,60
+Dólar de Conversão R$ 5,72 17/06 PICPAY LBL INTEGRA02/06 20,39
+17/06 binance.com 143,00 18/06 PICPAY LBL INTEGRA02/06 30,53
+Vilnius 135,00 BRL 25,00 18/06 PICPAY LBL INTEGRA02/06 57,01
+Dólar de Conversão R$ 5,72 18/06 PICPAY LBL INTEGRA02/06 65,15
+17/06 binance.com 174,80 Próxima fatura 788,04
+Vilnius 165,00 BRL 30,56 Demais faturas 4.315,88
+Dólar de Conversão R$ 5,72 Total para próximas faturas 5.103,92
+17/06 binance.com 127,10
+Vilnius 120,00 BRL 22,22
+Dólar de Conversão R$ 5,72
+Limites de crédito Valor em R$
+17/06 binance.com 143,00
+Vilnius 135,00 BRL 25,00
+Limite total de crédito: Flexível
+Dólar de Conversão R$ 5,72
+Limite disponível: - 2.118,05
+17/06 binance.com 164,16
+Limite utilizado total: 27.678,05
+Vilnius 155,00 BRL 28,70
+Dólar de Conversão R$ 5,72
+17/06 binance.com 144,09 Limite máximo para saque no Brasil: 1.000,00
+Vilnius 136,00 BRL 25,19 Limite máximo para saque no exterior: 7.000,00
+Dólar de Conversão R$ 5,72
+17/06 binance.com 141,97 O limite total de crédito compõe os limites de saque.
+Esses são os seus limites na data de fechamento dessa fatura. Caso queira
+Vilnius 134,00 BRL 24,82 consultar informações atualizadas sobre o seu limite, consulte nossos
+Dólar de Conversão R$ 5,72 canais.
+17/06 binance.com 195,97
+Vilnius 185,00 BRL 34,26
+Dólar de Conversão R$ 5,72
+17/06 binance.com 206,55 Encargos cobrados nesta fatura
+Vilnius 195,00 BRL 36,11 Juros do rotativo 9,99 % 175,20
+Dólar de Conversão R$ 5,72 Juros de mora 1,00 % am 17,18
+18/06 binance.com 193,85 Multa por atraso 2,00 % 114,64
+Vilnius 183,00 BRL 33,89 IOF de financiamento (0,38 % + 0,00820 % a.d.) 26,00
+Dólar de Conversão R$ 5,72 E Total de encargos em R$ 333,02
+18/06 binance.com 206,55
+Vilnius 195,00 BRL 36,11
+Dólar de Conversão R$ 5,72
+18/06 binance.com 188,53 Fique atento aos encargos para o próximo
+Vilnius 178,00 BRL 32,96 período (10/07 a 09/08)
+Dólar de Conversão R$ 5,72
+18/06 binance.com 189,62 Juros Máximos do contrato 10,32 % am 230,34 % aa
+Vilnius 179,00 BRL 33,15
+Dólar de Conversão R$ 5,72
+Total transações inter. em R$ 2.346,29
+Repasse de IOF em R$ 102,73
+Total lançamentos inter. em R$ 2.449,02
+Lançamentos: produtos e serviços
+DATA PRODUTOS/SERVIÇOS VALOR EM R$
+02/07 ENCARGOS DE ATRASO 21,47
+Continua...
+Novo teto de juros do cartão de crédito
+Valor em R$
+Crédito Rotativo / Atraso
+Valor da dívida origem: R$ 0,00
+Juros e encargos financeiros até o momento: R$ 0,00
+% juros sobre valor original dívida: 0,00 %
+Nos campos acima você pode consultar o valor da dívida origem das suas
+operações e os juros e encargos cobrados até o momento. O limite de
+juros é considerado individualmente por operação contratada.
+Simulação de Compras parc. c/ juros e
+Crediário (próximo período)
+Juros da compra parcelada 5,99 % am 102,95% aa
+CET da compra parcelada 6,32 % am 110,71 % aa
+% do total
+Valor em R$ financiado
+Valor compra 500,00 97,02 %
+Valor do IOF 15,34 2,98 %
+Valor total financiado 515,34 100,00%
+Valor juros 477,06
+Quantidade de parcelas 24
+Valor da parcela 41,35
+Valor total a pagar 992,40
+O valor do IOF compõe o valor financiado e será incluído nas
+parcelas.
+Ao contratar esse produto, você declara que opagamento dos
+valores devidosnãocompromete suarendamínima existencial.
+Simulação Saque Cash
+Limite de saque 1.000,00
+Juros 17,00 % am 575,45% aa
+CET 21,23 % am 940,33% aa
+% do total
+Valor em R$ financiado
+Valor saque 500,00 99,38 %
+Valor do IOF 3,14 0,62 %
+Valor total financiado 503,14 100,00%
+Valor juros 85,00
+Valor tarifa 18,00
+Valor total a pagar 606,14
+Demais Taxas de Juros próximo período
+De retirada de recursos país 10,32 % am
+De pagamento de contas 6,99 % am 127,51 % aa
+PC - 00 01290 VK045 03/07/2024 VKRPOF01 G4143 0670673
+LEONARDO BROCKSTEDT LECH ,
+Pague sua fatura com a opção de parcelamento que melhor cabe no seu bolso!
+Oferta válida até o dia do vencimento da sua fatura. Sua taxa de juros de parcelamento é de 5,45% a.m. e 90,72% a.a.
+Novidade: você também pode contar com uma das opções com seguro e garantir a quitação total ou parcial do saldo devedor
+do parcelamento em caso de desemprego involuntário, incapacidade total, morte ou invalidez permanente total.
+11 x de 10 x de 9 x de
+Sem seguro R$ 2.690,44 R$ 2.884,44 R$ 3.122,88
+Valor total financiado R$ 22.912,75 |100% R$ 22.880,23 |100% R$ 22.848,22 |100%
+Valor solicitado R$ 22.524,22 |98,30 % R$ 22.524,22 |98,44 % R$ 22.524,22 |98,58 %
+IOF R$ 388,53 |1,70 % R$ 356,01 |1,56 % R$ 324,00 |1,42 %
+CET 6,36 % a.m. - 111,74 % a.a. 6,37 % a.m. - 111,98 % a.a. 6,39 % a.m. - 112,47 % a.a.
+Total a pagar R$ 29.594,84 R$ 28.844,40 R$ 28.105,92
+Para contratar,pague o valor exato da parcela escolhida até o vencimento da fatura. Utilize o mesmo código de barras da fatura para
+efetuar o pagamento. Se preferir, simule outras opções no nosso app Itaú ou na Central de Atendimento.
+Importante: caso a sua fatura esteja em débito automático em uma instituição financeira diferente do Itaú, é necessário realizar o
+cancelamento desse serviço antes de contratar o Parcelamento de Fatura.
+O Parcelamento da Fatura tem incidência de encargos (juros e IOF) e inclui o valor total da fatura no momento da contratação. Outros valores como novas compras e parcelas a vencer, serão
+cobradas normalmente nas faturas seguintes. A contratação do parcelamento COM seguro é opcional e o valor do seguro será financiado utilizando a mesma taxa de juros, e será
+efetivada/formalizada com o pagamento da primeira parcela. O valor total do parcelamento comprometerá seu limite de crédito, que será recomposto à medida que as parcelas forem pagas.
+A simulação de qualquer opção em um de nossos outros canais, invalida as opções desta fatura.
+PC - 00 01290 VK045 03/07/2024 VKRPOF01 G4143 0670673

--- a/tests/data/Itau_2024-08.txt
+++ b/tests/data/Itau_2024-08.txt
@@ -1,0 +1,400 @@
+A992500005B
+PC -00
+LEONARDO BROCKSTEDT LECH
+Resumo da fatura em R$
+DOLOMITI 781
+101 - Planalto Total da fatura anterior 22.524,22
+59235600
+99250-000 Serafina Correa - RS
+Pagamento efetuado em 12/07/2024 - 22.524,22
+"@Cd#!
+S Saldo financiado 0,00
+Postagem: 03/08/2024 +
+E Encargos (financiamento + moratório) 685,97
+Vencimento: 10/08/2024 +
+L Lançamentos atuais 58.889,00
+Emissão: 02/08/2024
+030824 Previsão prox. Fechamento: 02/09/2024 = Total desta fatura 59.574,97
+Titular LEONARDO BROCKSTEDT LECH
+Cartão 5234.XXXX.XXXX.6853 MASTERCARD BLACK
+O total da sua fatura é: Com vencimento em: Limite total de crédito:
+R$ 59.574,97 10/08/2024 Flexível
+Preparamos outras opçõesdepagamento abaixo eaofinal dafatura, válidas atéadatadevencimento:
+Pagamento mínimo: Parcelas fixas:
+R$ 9.608,54 R$7.109,20
++ 10x R$ 7.109,20
+Valor em reais % do total financiado Valor em reais % do total financiado
+Valor total financiado R$ 49.966,43 100,00% Valor total financiado R$ 60.599,41 100,00%
+Encargos R$ 5.156,54 - Valor solicitado R$ 59.574,97 98,31 %
+IOF R$ 372,93 - IOF R$ 1.024,44 1,69 %
+Total a pagar R$ 65.104,44 - Total a pagar R$ 78.201,20 -
+Juros: 10,32 % am - 230,34 % aa CET: 10,95 % am - 253,88 % aa Juros: 5,45 % am - 90,72 % aa CET: 6,34 % am - 111,26 % aa
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 000 recibo do pagador
+Número do Documento 00406694061/0114435 Nosso Número 175/06694061-0
+Nome do Pagador/CPF/CNPJ LEONARDO BROCKSTEDT LECH - 024.244.030-40 Valor do Documento R$ 59.574,97
+Nome do Beneficiário/CPF/CNPJ ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23 Vencimento 10/08/2024
+Endereço do Beneficiário PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP Autenticação Mecânica
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 000
+Local de Pagamento Data de Vencimento
+Pague sua fatura em qualquer banco, mesmo após a data de vencimento. Dê preferência para o pagamento até a data de vencimento
+para não gerar encargos e/ou rescisão contratual. Em caso de atraso, os encargos serão cobrados na próxima fatura. 10/08/2024
+Nome do Beneficiário/ CNPJ/CPF/Endereço Agência / Código Beneficiário
+ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23
+PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP 2525/04345-7
+Data do Documento Número do Documento Espécie DOC. Aceite Data do Processamento Nosso Número
+10/08/2024 00406694061/0114435 FT N 02/08/2024 175/06694061-0
+Uso do Banco Carteira Espécie Quantidade Valor (=) Valor do Documento
+5/0 R$ R$ 59.574,97
+Instruções de responsabilidade do beneficiário. (-) Descontos / Abatimentos
+Indique o valor que deseja pagar no campo "Valor Pago". Dê preferência ao pagamento total. Não sendo possível, você terá as seguintes
+opções: (i) pagar quantia a partir do valor constante em Pagamento Mínimo , financiando o restante pelo crédito rotativo; (ii) optar por (+) Juros / Multa
+uma das opções de Parcelas Fixas , pagando o valor exato da parcela até a data do vencimento. O não pagamento poderá gerar
+inscrição nos órgãos restritivos de crédito. (=) Valor Pago
+Nome do Pagador/CPF/CNPJ/Endereço/Cidade/UF/CEP
+LEONARDO BROCKSTEDT LECH - 024.244.030-40
+<wwNnDNwONnNLwOnnWMNwITnnWI W7n8nn1W W- n1nnW0W1n n-nW PWlannnnWaWlntnnoW W- n9Nn9ww2N5Nn0Nw-w0nN0W0w n nSWewNrnannWfiNnwaNw CwnNonNrwrweNawN -w nRNwSnW -NnNNwnwNnWnwnnNWwnnWWn>
+Sacador Avalista:
+Autenticação Mecânica - Ficha de Compensação
+Caso você pague um valor entre o mínimo e o total de sua fatura, o saldo restante será cobrado na próxima fatura com juros e impostos. O pagamento
+do valor total é sempre a melhor opção porque não há cobranças de juros.
+O pagamento obrigatório é composto pelo saldo do crédito rotativo e respectivos encargos incidentes no período (R$ 790,93), prestações referentes a
+parcelamentos do saldo devedor de períodos anteriores (R$ 0,00) e valor mínimo de novas transações (R$ 8.817,61). Para entender mais sobre o
+pagamento obrigatório e o pagamento mínimo, acesse seu contrato e a aba "Serviços" no site Itaú Cartões.
+Consulte outras opções de parcelamento no final da sua fatura.
+Previsão do próximo fechamento: 02/09/2024.
+Lançamentos: compras e saques Lançamentos: compras e saques
+LEONARDO B LECH (final 6853) 04/07 IFD*MISO DELIVERY LTDA 65,00
+DATA ESTABELECIMENTO VALOR EM R$ VEÍCULOS .PASSO FUNDO
+08/05 GRIFE NATURAL 03/03 97,12 05/07 BOURBON PASSO FUNDO 123,09
+ALIMENTAÇÃO .PASSO FUNDO ALIMENTAÇÃO .PASSO FUNDO
+28/05 FARMACIA SAO JOAO 03/06 39,40 06/07 FARMACIA SAO JOAO 01/06 81,09
+SAÚDE .CAXIAS DO SUL SAÚDE .
+10/06 FARMACIA SAO JOAO 02/06 87,64 06/07 PAG*PostoBrasil 7,98
+SAÚDE .PASSO FUNDO VEÍCULOS .PASSO FUNDO
+10/06 FARMACIA SAO JOAO - 0,05 08/07 BOURBON PASSO FUNDO 36,78
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .PASSO FUNDO
+01/07 IFD*MISO DELIVERY LTDA 53,00 08/07 IFD*HUKILAU RESTAURANT 82,00
+VEÍCULOS .PASSO FUNDO ALIMENTAÇÃO .PASSO FUNDO
+02/07 RECARGAPAY *LEONARDOB 93,50 Lançamentos no cartão (final 6853) 1.437,69
+DIVERSOS .Sao Paulo
+02/07 RECARGAPAY *LEONARDOB 25,97 LEONARDO B LECH (final 9779)
+DIVERSOS .SAO PAULO DATA ESTABELECIMENTO VALOR EM R$
+02/07 RECARGAPAY *LEONARDOB 88,31 16/06 RECARGAPAY *LEONA02/12 18,28
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+02/07 RECARGAPAY *LEONARDOB 94,54 16/06 RECARGAPAY *LEONA02/12 11,08
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+02/07 RECARGAPAY *LEONARDOB 77,92 16/06 RECARGAPAY *LEONA02/12 40,44
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+02/07 RECARGAPAY *LEONARDOB 72,72 16/06 RECARGAPAY *LEONA02/12 12,74
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+02/07 RECARGAPAY *LEONARDOB 98,70 16/06 RECARGAPAY *LEONA02/12 20,50
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+02/07 RECARGAPAY *LEONARDOB 95,58 16/06 RECARGAPAY *LEONA02/12 21,61
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+03/07 IFD*MISO DELIVERY LTDA 64,50 16/06 RECARGAPAY *LEONA02/12 60,94
+VEÍCULOS .PASSO FUNDO DIVERSOS .SAO PAULO
+04/07 FARMACIA SAO JOAO 52,90 16/06 RECARGAPAY *LEONA02/12 13,30
+SAÚDE .PASSO FUNDO DIVERSOS .SAO PAULO
+Continua...
+3003 3030
+0800 720 3030
+PC - 00 01290 VK045 03/08/2024 VKRPOF01 G4174 0653295
+Lançamentos: compras e saques Lançamentos: compras e saques
+16/06 RECARGAPAY *LEONA02/12 14,96 17/07 RECARGAPAY *LEONA01/06 202,77
+DIVERSOS .SAO PAULO DIVERSOS .
+16/06 RECARGAPAY *LEONA02/12 11,63 Lançamentos no cartão (final 3549) 9.718,82
+DIVERSOS .SAO PAULO
+Lançamentos no cartão (final 9779) 225,48 Lançamentos internacionais
+LEONARDO B LECH (final 6853)
+LEONARDO B LECH (final 9835) DATA ESTABELECIMENTO US$ R$
+DATA ESTABELECIMENTO VALOR EM R$ 08/07 binance.com 126,86
+17/06 PICPAY LBL INTEGRA02/12 11,59 Vilnius 120,00 BRL 21,91
+DIVERSOS .S o Paulo Dólar de Conversão R$ 5,79
+17/06 PICPAY LBL INTEGRA02/12 46,13 08/07 binance.com 133,23
+DIVERSOS .S o Paulo Vilnius 126,00 BRL 23,01
+17/06 PICPAY LBL INTEGRA02/05 107,60 Dólar de Conversão R$ 5,79
+DIVERSOS .S o Paulo 08/07 binance.com 163,91
+17/06 PICPAY LBL INTEGRA02/06 20,39 Vilnius 155,00 BRL 28,31
+DIVERSOS .S o Paulo Dólar de Conversão R$ 5,79
+17/06 PICPAY LBL INTEGRACA - 0,99 08/07 binance.com 142,72
+DIVERSOS .S o Paulo Vilnius 135,00 BRL 24,65
+17/06 PICPAY LBL INTEGRACA - 1,21 Dólar de Conversão R$ 5,79
+DIVERSOS .S o Paulo 08/07 binance.com 317,23
+17/06 PICPAY LBL INTEGRACA - 0,04 Vilnius 300,00 BRL 54,79
+DIVERSOS .S o Paulo Dólar de Conversão R$ 5,79
+17/06 PICPAY LBL INTEGRACA - 0,25 08/07 binance.com 370,10
+DIVERSOS .S o Paulo Vilnius 350,00 BRL 63,92
+18/06 PICPAY LBL INTEGRA02/06 30,53 Dólar de Conversão R$ 5,79
+DIVERSOS .S o Paulo 08/07 binance.com 475,82
+18/06 PICPAY LBL INTEGRA02/06 57,01 Vilnius 450,00 BRL 82,18
+DIVERSOS .S o Paulo Dólar de Conversão R$ 5,79
+18/06 PICPAY LBL INTEGRA02/06 65,15 08/07 binance.com 370,10
+DIVERSOS .S o Paulo Vilnius 350,00 BRL 63,92
+18/06 PICPAY LBL INTEGRACA - 0,05 Dólar de Conversão R$ 5,79
+DIVERSOS .S o Paulo 08/07 binance.com 444,09
+18/06 PICPAY LBL INTEGRACA - 0,20 Vilnius 420,00 BRL 76,70
+DIVERSOS .S o Paulo Dólar de Conversão R$ 5,79
+18/06 PICPAY LBL INTEGRACA - 0,20 09/07 binance.com 370,10
+DIVERSOS .S o Paulo Vilnius 350,00 BRL 63,92
+Lançamentos no cartão (final 9835) 335,46 Dólar de Conversão R$ 5,79
+09/07 binance.com 470,55
+LEONARDO B LECH (final 3549) Vilnius 445,00 BRL 81,27
+DATA ESTABELECIMENTO VALOR EM R$ Dólar de Conversão R$ 5,79
+02/07 RECARGAPAY *LEONARDOB 96,62 09/07 binance.com 475,82
+DIVERSOS .SAO PAULO Vilnius 450,00 BRL 82,18
+02/07 RECARGAPAY *LEONARDOB 234,79 Dólar de Conversão R$ 5,79
+DIVERSOS .SAO PAULO 09/07 binance.com 518,09
+02/07 RECARGAPAY *LEONARDOB 675,29 Vilnius 490,00 BRL 89,48
+DIVERSOS .SAO PAULO Dólar de Conversão R$ 5,79
+03/07 RECARGAPAY *LEONARDOB 748,01 09/07 binance.com 527,64
+DIVERSOS .SAO PAULO Vilnius 499,00 BRL 91,13
+03/07 RECARGAPAY *LEONARDOB 883,07 Dólar de Conversão R$ 5,79
+DIVERSOS .SAO PAULO 09/07 binance.com 527,64
+03/07 RECARGAPAY *LEONARDOB 592,17 Vilnius 499,00 BRL 91,13
+DIVERSOS .SAO PAULO Dólar de Conversão R$ 5,79
+04/07 RECARGAPAY LEONARDOBRO 1.163,57 10/07 binance.com 261,69
+DIVERSOS .SAO PAULO Vilnius 250,00 BRL 45,83
+05/07 RECARGAPAY LEONARDOBRO 581,78 Dólar de Conversão R$ 5,71
+DIVERSOS .SAO PAULO 10/07 binance.com 366,35
+05/07 RECARGAPAY LEONARDOBRO 2.077,80 Vilnius 350,00 BRL 64,16
+DIVERSOS .SAO PAULO Dólar de Conversão R$ 5,71
+05/07 RECARGAPAY LEONARD01/06 409,64 10/07 binance.com 471,02
+DIVERSOS . Vilnius 450,00 BRL 82,49
+07/07 RECARGAPAY LEONARD01/06 532,53 Dólar de Conversão R$ 5,71
+DIVERSOS . 10/07 binance.com 511,84
+07/07 RECARGAPAY LEONARD01/06 532,53 Vilnius 489,00 BRL 89,64
+DIVERSOS . Dólar de Conversão R$ 5,71
+07/07 RECARGAPAY LEONARD01/06 614,46 10/07 binance.com 519,15
+DIVERSOS . Vilnius 496,00 BRL 90,92
+07/07 RECARGAPAY LEONARD01/06 245,78 Dólar de Conversão R$ 5,71
+DIVERSOS . 10/07 binance.com 522,29
+17/07 RECARGAPAY *LEONA01/06 25,60 Vilnius 499,00 BRL 91,47
+DIVERSOS . Dólar de Conversão R$ 5,71
+17/07 RECARGAPAY *LEONA01/06 102,41
+DIVERSOS .
+Continua...
+Lançamentos internacionais Lançamentos internacionais
+10/07 binance.com 522,29 12/07 binance.com 133,52
+Vilnius 499,00 BRL 91,47 Vilnius 125,00 BRL 23,14
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,77
+10/07 binance.com 516,01 12/07 binance.com 148,46
+Vilnius 493,00 BRL 90,37 Vilnius 139,00 BRL 25,73
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,77
+10/07 binance.com 522,29 12/07 binance.com 145,23
+Vilnius 499,00 BRL 91,47 Vilnius 136,00 BRL 25,17
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,77
+10/07 binance.com 522,29 12/07 binance.com 159,14
+Vilnius 499,00 BRL 91,47 Vilnius 149,00 BRL 27,58
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,77
+10/07 binance.com 522,29 17/07 RAMP (SJYSEDDQM2P9ZHA) 1.734,00
+Vilnius 499,00 BRL 91,47 LONDON 300,00 USD 300,00
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,78
+10/07 binance.com 522,29 17/07 RAMP (SQ4UBAY9N6YCY9J) 867,00
+Vilnius 499,00 BRL 91,47 LONDON 150,00 USD 150,00
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,78
+10/07 binance.com 527,43 17/07 RAMP (STWAJ3HSC5NQ98T) 1.734,00
+Vilnius 499,00 BRL 92,37 LONDON 300,00 USD 300,00
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,78
+10/07 binance.com 527,43 17/07 RAMP (S7KZTR5ZDJWMAVU) 1.734,00
+Vilnius 499,00 BRL 92,37 LONDON 300,00 USD 300,00
+Dólar de Conversão R$ 5,71 Dólar de Conversão R$ 5,78
+11/07 binance.com 528,36 17/07 binance.com 133,00
+Vilnius 499,00 BRL 92,37 Vilnius 125,00 BRL 23,01
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,78
+11/07 binance.com 317,63 17/07 binance.com 530,84
+Vilnius 300,00 BRL 55,53 Vilnius 499,00 BRL 91,84
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,78
+11/07 binance.com 370,60 17/07 binance.com 1.010,63
+Vilnius 350,00 BRL 64,79 Vilnius 950,00 BRL 174,85
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,78
+11/07 binance.com 422,48 17/07 BANXA BITPAY 14515393 1.734,00
+Vilnius 399,00 BRL 73,86 RENO 300,00 USD 300,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,78
+11/07 binance.com 370,60 18/07 RAMP (SDMTZG4PYQKR5RK) 1.758,12
+Vilnius 350,00 BRL 64,79 LONDON 300,02 USD 300,02
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,86
+11/07 binance.com 370,60 18/07 RAMP (SND3RWQN9PZKRD8) 1.758,12
+Vilnius 350,00 BRL 64,79 LONDON 300,02 USD 300,02
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,86
+11/07 binance.com 411,90 21/07 RAMP (SWH2BCR7RQHKPG9) 558,60
+Vilnius 389,00 BRL 72,01 LONDON 95,00 USD 95,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,88
+11/07 binance.com 422,48 21/07 RAMP (SZ7W2772PYDOSYX) 499,62
+Vilnius 399,00 BRL 73,86 LONDON 84,97 USD 84,97
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,88
+11/07 binance.com 422,48 29/07 BANXA BITPAY 14666978 298,50
+Vilnius 399,00 BRL 73,86 RENO 50,00 USD 50,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,97
+11/07 binance.com 528,36 29/07 BANXA BITPAY 14666999 507,45
+Vilnius 499,00 BRL 92,37 RENO 85,00 USD 85,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,97
+11/07 binance.com 168,34 29/07 BANXA BITPAY 14667289 567,15
+Vilnius 159,00 BRL 29,43 RENO 95,00 USD 95,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,97
+11/07 binance.com 210,67 29/07 BANXA BITPAY 14667795 531,33
+Vilnius 199,00 BRL 36,83 RENO 89,00 USD 89,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,97
+11/07 binance.com 210,67 29/07 BANXA BITPAY 14668930 298,50
+Vilnius 199,00 BRL 36,83 RENO 50,00 USD 50,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,97
+11/07 binance.com 132,36 29/07 BANXA BITPAY 14669043 388,05
+Vilnius 125,00 BRL 23,14 RENO 65,00 USD 65,00
+Dólar de Conversão R$ 5,72 Dólar de Conversão R$ 5,97
+12/07 binance.com 319,31 29/07 BANXA BITPAY 14669428 507,45
+Vilnius 299,00 BRL 55,34 RENO 85,00 USD 85,00
+Dólar de Conversão R$ 5,77 Dólar de Conversão R$ 5,97
+12/07 binance.com 306,50 30/07 BANXA BITPAY 14678943 550,16
+Vilnius 287,00 BRL 53,12 RENO 92,00 USD 92,00
+Dólar de Conversão R$ 5,77 Dólar de Conversão R$ 5,98
+Continua...
+PC - 00 01290 VK045 03/08/2024 VKRPOF01 G4174 0653295
+Lançamentos internacionais Lançamentos: produtos e serviços
+30/07 BANXA BITPAY 14678969 520,26 03/07 JUROS PAGAMENTO CONTAS 39,52
+RENO 87,00 USD 87,00
+Dólar de Conversão R$ 5,98 04/07 IOF PAGAMENTO CONTAS 5,44
+30/07 BANXA BITPAY 14679454 406,64 0,69 % do total financiado
+RENO 68,00 USD 68,00 02/08 ENCARGOS DE ATRASO 59,65
+Dólar de Conversão R$ 5,98
+30/07 BANXA BITPAY 14684263 328,90 02/08 JUROS PAGAMENTO CONTAS 0,40
+RENO 55,00 USD 55,00
+Dólar de Conversão R$ 5,98 Lançamentos produtos e serviços 886,75
+30/07 BANXA BITPAY 14686308 436,54
+RENO 73,00 USD 73,00 Outros lançamentos
+Dólar de Conversão R$ 5,98
+DATA DESCRIÇÃO VALOR EM R$
+30/07 BANXA BITPAY 14686339 394,68
+02/08 ESTORNO JUROS DE FINANC - 0,12
+RENO 66,00 USD 66,00
+Total de outros lançamentos - 0,12
+Dólar de Conversão R$ 5,98
+31/07 BANXA BITPAY 14695677 533,11
+RENO 89,00 USD 89,00
+Dólar de Conversão R$ 5,99 L Total dos lançamentos atuais 58.889,00
+31/07 BANXA BITPAY 14695699 473,21
+RENO 79,00 USD 79,00 Compras parceladas - próximas faturas
+Dólar de Conversão R$ 5,99 DATA ESTABELECIMENTO VALOR EM R$
+31/07 BANXA BITPAY 14695762 521,13 28/05 FARMACIA SAO JOAO 04/06 39,40
+RENO 87,00 USD 87,00 10/06 FARMACIA SAO JOAO 03/06 87,64
+Dólar de Conversão R$ 5,99 16/06 RECARGAPAY *LEONA03/12 18,28
+31/07 BANXA BITPAY 14697943 389,35 16/06 RECARGAPAY *LEONA03/12 11,08
+RENO 65,00 USD 65,00 16/06 RECARGAPAY *LEONA03/12 40,44
+Dólar de Conversão R$ 5,99 16/06 RECARGAPAY *LEONA03/12 12,74
+31/07 BANXA BITPAY 14697958 449,25 16/06 RECARGAPAY *LEONA03/12 20,50
+RENO 75,00 USD 75,00 16/06 RECARGAPAY *LEONA03/12 21,61
+Dólar de Conversão R$ 5,99 16/06 RECARGAPAY *LEONA03/12 60,94
+31/07 BANXA BITPAY 14698003 329,45 16/06 RECARGAPAY *LEONA03/12 13,30
+RENO 55,00 USD 55,00 16/06 RECARGAPAY *LEONA03/12 14,96
+Dólar de Conversão R$ 5,99 16/06 RECARGAPAY *LEONA03/12 11,63
+31/07 BANXA BITPAY 14698508 329,45 17/06 PICPAY LBL INTEGRA03/12 11,59
+RENO 55,00 USD 55,00 17/06 PICPAY LBL INTEGRA03/12 46,13
+Dólar de Conversão R$ 5,99 17/06 PICPAY LBL INTEGRA03/05 107,60
+31/07 BANXA BITPAY 14698550 569,05 17/06 PICPAY LBL INTEGRA03/06 20,39
+RENO 95,00 USD 95,00 18/06 PICPAY LBL INTEGRA03/06 30,53
+Dólar de Conversão R$ 5,99 18/06 PICPAY LBL INTEGRA03/06 57,01
+31/07 BANXA BITPAY 14702232 449,25 18/06 PICPAY LBL INTEGRA03/06 65,15
+RENO 75,00 USD 75,00 05/07 RECARGAPAY LEONARD02/06 409,64
+Dólar de Conversão R$ 5,99 06/07 FARMACIA SAO JOAO 02/06 81,09
+31/07 BANXA BITPAY 14688156 455,24 07/07 RECARGAPAY LEONARD02/06 532,53
+RENO 76,00 USD 76,00 07/07 RECARGAPAY LEONARD02/06 532,53
+Dólar de Conversão R$ 5,99 07/07 RECARGAPAY LEONARD02/06 614,46
+31/07 BANXA BITPAY 14688173 533,11 07/07 RECARGAPAY LEONARD02/06 245,78
+RENO 89,00 USD 89,00 17/07 RECARGAPAY *LEONA02/06 25,60
+Dólar de Conversão R$ 5,99 17/07 RECARGAPAY *LEONA02/06 102,41
+31/07 BANXA BITPAY 14688228 509,15 17/07 RECARGAPAY *LEONA02/06 202,77
+RENO 85,00 USD 85,00 Próxima fatura 3.437,73
+Dólar de Conversão R$ 5,99 Demais faturas 14.612,20
+01/08 binance.com 478,20 Total para próximas faturas 18.049,93
+Vilnius 450,00 BRL 79,70
+Dólar de Conversão R$ 6,00
+Total transações inter. em R$ 44.174,74
+Limites de crédito Valor em R$
+Repasse de IOF em R$ 1.935,22
+Total lançamentos inter. em R$ 46.109,96
+Limite total de crédito Flexível
+Limite total utilizado 77.446,06
+LEONARDO B LECH (final 3549)
+DATA ESTABELECIMENTO US$ R$
+Limite máximo para saque no Brasil 1.000,00
+17/07 TRADEZELLA 167,62
+Limite máximo para saque no exterior 7.000,00
+STATEN ISLAND 29,00 USD 29,00
+Dólar de Conversão R$ 5,78 O limite total de crédito é composto pelos limites de saque.
+Total transações inter. em R$ 167,62 Esses são os seus limites na data de fechamento dessa fatura. Caso
+Repasse de IOF em R$ 7,34 queira consultar informações atualizadas sobre o seu limite, consulte
+Total lançamentos inter. em R$ 174,96 nossos canais.
+Lançamentos: produtos e serviços
+DATA PRODUTOS/SERVIÇOS VALOR EM R$ Encargos cobrados nesta fatura
+03/07 PAGTO CONTA TITULOS 781,74
+Juros do rotativo 10,32 % 152,86
+Continua...
+Encargos cobrados nesta fatura
+Juros de mora 1,00 % am 15,00
+Multa por atraso 2,00 % 450,42
+IOF de financiamento (0,38 % + 0,00820 % a.d.) 67,69
+E Total de encargos em R$ 685,97
+Fique atento aos encargos para o próximo
+período (10/08 a 09/09)
+Juros Máximos do contrato 10,32 % am 230,34 % aa
+Novo teto de juros do cartão de crédito
+Valor em R$
+Crédito Rotativo / Atraso
+Valor da dívida origem: R$ 0,00
+Juros e encargos financeiros até o momento: R$ 0,00
+% juros sobre valor original dívida: 0,00 %
+Nos campos acima você pode consultar o valor da dívida origem das
+suas operações e os juros e encargos cobrados até o momento. O
+limite de juros é considerado individualmente por operação
+contratada.
+Simulação de Compras parc. c/ juros e
+Crediário (próximo período)
+Juros da compra parcelada 5,99 % am 102,95% aa
+CET da compra parcelada 6,32 % am 110,71 % aa
+% do total
+Valor em R$ financiado
+Valor compra 500,00 97,02 %
+Valor do IOF 15,34 2,98 %
+Valor total financiado 515,34 100,00%
+Valor juros 477,06
+Quantidade de parcelas 24
+Valor da parcela 41,35
+Valor total a pagar 992,40
+O valor do IOF compõe o valor financiado e será incluído nas
+parcelas.
+Ao contratar esse produto, você declara que opagamento dos
+valores devidosnãocompromete suarendamínima existencial.
+Simulação Saque Cash
+Limite de saque 1.000,00
+Juros 17,00 % am 575,45% aa
+CET 21,23 % am 940,33% aa
+% do total
+Valor em R$ financiado
+Valor saque 500,00 99,38 %
+Valor do IOF 3,14 0,62 %
+Valor total financiado 503,14 100,00%
+Valor juros 85,00
+Valor tarifa 18,00
+Valor total a pagar 606,14
+Demais Taxas de Juros próximo período
+De retirada de recursos país 10,32 % am
+De pagamento de contas 6,99 % am 127,51 % aa
+PC - 00 01290 VK045 03/08/2024 VKRPOF01 G4174 0653295
+LEONARDO BROCKSTEDT LECH ,
+Pague sua fatura com a opção de parcelamento que melhor cabe no seu bolso!
+Oferta válida até o dia do vencimento da sua fatura. Sua taxa de juros de parcelamento é de 5,45% a.m. e 90,72% a.a.
+4 x de 6 x de 8 x de
+Sem seguro R$ 16.249,18 R$ 11.435,39 R$ 9.044,09
+Valor total financiado R$ 60.027,24 |100% R$ 60.183,90 |100% R$ 60.345,97 |100%
+Valor solicitado R$ 59.574,97 |99,25 % R$ 59.574,97 |98,99 % R$ 59.574,97 |98,72 %
+IOF R$ 452,27 |0,75 % R$ 608,93 |1,01 % R$ 771,00 |1,28 %
+CET 6,67 % a.m. - 119,37 % a.a. 6,46 % a.m. - 114,17 % a.a. 6,38 % a.m. - 112,22 % a.a.
+Total a pagar R$ 64.996,72 R$ 68.612,34 R$ 72.352,72
+Para contratar,pague o valor exato da parcela escolhida até o vencimento da fatura. Utilize o mesmo código de barras da fatura para
+efetuar o pagamento. Se preferir, simule outras opções no nosso app Itaú ou na Central de Atendimento.
+Importante: caso a sua fatura esteja em débito automático em uma instituição financeira diferente do Itaú, é necessário realizar o
+cancelamento desse serviço antes de contratar o Parcelamento de Fatura.
+O Parcelamento da Fatura tem incidência de encargos (juros e IOF) e inclui o valor total da fatura no momento da contratação. Outros valores como novas compras e parcelas a vencer, serão
+cobradas normalmente nas faturas seguintes. A contratação do parcelamento COM seguro é opcional e o valor do seguro será financiado utilizando a mesma taxa de juros, e será
+efetivada/formalizada com o pagamento da primeira parcela. O valor total do parcelamento comprometerá seu limite de crédito, que será recomposto à medida que as parcelas forem pagas.
+A simulação de qualquer opção em um de nossos outros canais, invalida as opções desta fatura.
+PC - 00 01290 VK045 03/08/2024 VKRPOF01 G4174 0653295

--- a/tests/data/Itau_2024-09.txt
+++ b/tests/data/Itau_2024-09.txt
@@ -1,0 +1,218 @@
+A992500005B
+PC -00
+LEONARDO BROCKSTEDT LECH
+Resumo da fatura em R$
+DOLOMITI 781
+101 - Planalto Total da fatura anterior 59.574,97
+58131700
+99250-000 Serafina Correa - RS
+P Pagamentos efetuados 0,00
+"xBj#!
+S Saldo financiado 59.574,97
+Postagem: 03/09/2024 +
+E Encargos (financiamento + moratório) 8.362,93
+Vencimento: 10/09/2024 +
+L Lançamentos atuais 3.605,34
+Emissão: 02/09/2024
+030924 Previsão prox. Fechamento: 02/10/2024 = Total desta fatura 71.543,24
+Titular LEONARDO BROCKSTEDT LECH
+Cartão 5234.XXXX.XXXX.6853 MASTERCARD BLACK
+O total da sua fatura é: Com vencimento em: Limite total de crédito:
+R$ 71.543,24 10/09/2024 Flexível
+Preparamos outras opçõesdepagamento abaixo eaofinal dafatura, válidas atéadatadevencimento:
+Pagamento mínimo:
+R$ 10.731,42
++ 12x R$ 8.055,92
+Valor em reais % do total financiado
+Valor total financiado R$ 62.186,30 100,00% Parcelas fixas:
+Consulte outras opções de parcelamento no final
+Valor solicitado R$ 60.811,82 97,79 % da sua fatura.
+IOF R$ 1.374,48 2,21%
+Total a pagar R$ 96.671,04 -
+Juros: 7,45 % am - 139,71 % aa CET: 7,94 % am - 153,35 % aa
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 000 recibo do pagador
+Número do Documento 00406694061/0123719 Nosso Número 175/06694061-0
+Nome do Pagador/CPF/CNPJ LEONARDO BROCKSTEDT LECH - 024.244.030-40 Valor do Documento R$ 71.543,24
+Nome do Beneficiário/CPF/CNPJ ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23 Vencimento 10/09/2024
+Endereço do Beneficiário PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP Autenticação Mecânica
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 000
+Local de Pagamento Data de Vencimento
+Pague sua fatura em qualquer banco, mesmo após a data de vencimento. Dê preferência para o pagamento até a data de vencimento
+para não gerar encargos e/ou rescisão contratual. Em caso de atraso, os encargos serão cobrados na próxima fatura. 10/09/2024
+Nome do Beneficiário/ CNPJ/CPF/Endereço Agência / Código Beneficiário
+ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23
+PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP 2525/04345-7
+Data do Documento Número do Documento Espécie DOC. Aceite Data do Processamento Nosso Número
+10/09/2024 00406694061/0123719 FT N 02/09/2024 175/06694061-0
+Uso do Banco Carteira Espécie Quantidade Valor (=) Valor do Documento
+5/0 R$ R$ 71.543,24
+Instruções de responsabilidade do beneficiário. (-) Descontos / Abatimentos
+Indique o valor que deseja pagar no campo "Valor Pago". Dê preferência ao pagamento total. Não sendo possível, você terá as seguintes
+opções: (i) Pagar quantia, a partir do valor constante em Pagamento Mínimo , financiando o restante da Fatura em parcelas iguais, com (+) Juros / Multa
+os mesmos juros de Parcelas Fixas ; (ii) optar por uma das opções de Parcelas Fixas disponíveis na 2 folha da sua fatura, pagando
+o valor exato da parcela até a data do vencimento. O não pagamento poderá gerar inscrição nos órgãos restritivos de crédito. (=) Valor Pago
+Nome do Pagador/CPF/CNPJ/Endereço/Cidade/UF/CEP
+LEONARDO BROCKSTEDT LECH - 024.244.030-40
+<wwNnDNwONnNLwOnnWMNwITnnWI W7n8nn1W W- n1nnW0W1n n-nW PWlannnnWaWlntnnoW W- n9Nn9ww2N5Nn0Nw-w0nN0W0w n nSWewNrnannWfiNnwaNw CwnNonNrwrweNawN -w nRNwSnW -NnNNwnwNnWnwnnNWwnnWWn>
+Sacador Avalista:
+Autenticação Mecânica - Ficha de Compensação
+Ao pagar qualquer valor entre o pagamento mínimo e o total, o valor pago será considerado como entrada e o saldo restante será parcelado em 12x
+com juros e impostos. O pagamento do valor total é sempre a melhor opção porque não há cobranças de juros.
+O pagamento obrigatório é composto pelo saldo do crédito rotativo e respectivos encargos incidentes no período (R$ 67.937,68), prestações referentes
+a parcelamentos do saldo devedor de períodos anteriores (R$ 0,00) e valor mínimo de novas transações (R$ 3.605,56). Para entender mais sobre o
+pagamento obrigatório e o pagamento mínimo, acesse seu contrato e a aba "Serviços" no site Itaú Cartões.
+Consulte outras opções de parcelamento no final da sua fatura.
+Previsão do próximo fechamento: 02/10/2024.
+Lançamentos: compras e saques Lançamentos: compras e saques
+LEONARDO B LECH (final 6853) 16/06 RECARGAPAY *LEONA03/12 11,63
+DATA ESTABELECIMENTO VALOR EM R$ DIVERSOS .SAO PAULO
+28/05 FARMACIA SAO JOAO 04/06 39,40 Lançamentos no cartão (final 9779) 225,48
+SAÚDE .CAXIAS DO SUL
+10/06 FARMACIA SAO JOAO 03/06 87,64 LEONARDO B LECH (final 9835)
+SAÚDE .PASSO FUNDO DATA ESTABELECIMENTO VALOR EM R$
+06/07 FARMACIA SAO JOAO 02/06 81,09 17/06 PICPAY LBL INTEGRA03/12 11,59
+SAÚDE .PASSO FUNDO DIVERSOS .S o Paulo
+06/07 FARMACIA SAO JOAO - 0,20 17/06 PICPAY LBL INTEGRA03/12 46,13
+SAÚDE .PASSO FUNDO DIVERSOS .S o Paulo
+Lançamentos no cartão (final 6853) 207,93 17/06 PICPAY LBL INTEGRA03/05 107,60
+DIVERSOS .S o Paulo
+LEONARDO B LECH (final 9779) 17/06 PICPAY LBL INTEGRA03/06 20,39
+DATA ESTABELECIMENTO VALOR EM R$ DIVERSOS .S o Paulo
+16/06 RECARGAPAY *LEONA03/12 18,28 18/06 PICPAY LBL INTEGRA03/06 30,53
+DIVERSOS .SAO PAULO DIVERSOS .S o Paulo
+16/06 RECARGAPAY *LEONA03/12 11,08 18/06 PICPAY LBL INTEGRA03/06 57,01
+DIVERSOS .SAO PAULO DIVERSOS .S o Paulo
+16/06 RECARGAPAY *LEONA03/12 40,44 18/06 PICPAY LBL INTEGRA03/06 65,15
+DIVERSOS .SAO PAULO DIVERSOS .S o Paulo
+16/06 RECARGAPAY *LEONA03/12 12,74 Lançamentos no cartão (final 9835) 338,40
+DIVERSOS .SAO PAULO
+16/06 RECARGAPAY *LEONA03/12 20,50 LEONARDO B LECH (final 3549)
+DIVERSOS .SAO PAULO DATA ESTABELECIMENTO VALOR EM R$
+16/06 RECARGAPAY *LEONA03/12 21,61 05/07 RECARGAPAY LEONARD02/06 409,64
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+16/06 RECARGAPAY *LEONA03/12 60,94 07/07 RECARGAPAY LEONARD02/06 532,53
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+16/06 RECARGAPAY *LEONA03/12 13,30 07/07 RECARGAPAY LEONARD02/06 532,53
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+16/06 RECARGAPAY *LEONA03/12 14,96 07/07 RECARGAPAY LEONARD02/06 614,46
+DIVERSOS .SAO PAULO DIVERSOS .SAO PAULO
+Continua...
+3003 3030
+0800 720 3030
+PC - 00 01290 VK045 03/09/2024 VKRPOF01 G4205 0713185
+Lançamentos: compras e saques
+07/07 RECARGAPAY LEONARD02/06 245,78 Limites de crédito Valor em R$
+DIVERSOS .SAO PAULO
+17/07 RECARGAPAY *LEONA02/06 25,60 Limite total de crédito Flexível
+DIVERSOS .SAO PAULO Limite total utilizado 85.826,60
+17/07 RECARGAPAY *LEONA02/06 102,41
+DIVERSOS .SAO PAULO Limite máximo para saque no Brasil 1.000,00
+17/07 RECARGAPAY *LEONA02/06 202,77 Limite máximo para saque no exterior 7.000,00
+DIVERSOS .SAO PAULO
+Lançamentos no cartão (final 3549) 2.665,72 O limite total de crédito é composto pelos limites de saque.
+Esses são os seus limites na data de fechamento dessa fatura. Caso
+queira consultar informações atualizadas sobre o seu limite, consulte
+Lançamentos internacionais nossos canais.
+LEONARDO B LECH (final 6853)
+DATA ESTABELECIMENTO US$ R$
+02/08 binance.com 160,79
+Vilnius 150,00 BRL 26,49 Encargos cobrados nesta fatura
+Dólar de Conversão R$ 6,07 Juros do rotativo 10,32 % 6.264,48
+Total transações inter. em R$ 160,79 Juros de mora 1,00 % am 615,06
+Repasse de IOF em R$ 7,04 Multa por atraso 2,00 % 1.191,50
+Total lançamentos inter. em R$ 167,83 IOF de financiamento (0,38 % + 0,00820 % a.d.) 291,89
+E Total de encargos em R$ 8.362,93
+Outros lançamentos
+DATA DESCRIÇÃO VALOR EM R$
+02/09 ESTORNO JUROS DE FINANC - 0,02 Fique atento aos encargos para o próximo
+Total de outros lançamentos - 0,02 período (10/09 a 09/10)
+Juros Máximos do contrato 9,99 % am 218,52 % aa
+L Total dos lançamentos atuais 3.605,34
+Compras parceladas - próximas faturas Novo teto de juros do cartão de crédito
+DATA ESTABELECIMENTO VALOR EM R$
+28/05 FARMACIA SAO JOAO 05/06 39,40 Valor em R$
+10/06 FARMACIA SAO JOAO 04/06 87,64
+16/06 RECARGAPAY *LEONA04/12 18,28 Crédito Rotativo / Atraso
+16/06 RECARGAPAY *LEONA04/12 11,08 Valor da dívida origem: R$ 59.574,75
+16/06 RECARGAPAY *LEONA04/12 40,44 Juros e encargos financeiros até o momento: R$ 8.071,04
+16/06 RECARGAPAY *LEONA04/12 12,74 % juros sobre valor original dívida: 13,55 %
+16/06 RECARGAPAY *LEONA04/12 20,50
+16/06 RECARGAPAY *LEONA04/12 21,61
+16/06 RECARGAPAY *LEONA04/12 60,94 Nos campos acima você pode consultar o valor da dívida origem das
+suas operações e os juros e encargos cobrados até o momento. O
+16/06 RECARGAPAY *LEONA04/12 13,30
+limite de juros é considerado individualmente por operação
+16/06 RECARGAPAY *LEONA04/12 14,96 contratada.
+16/06 RECARGAPAY *LEONA04/12 11,63
+17/06 PICPAY LBL INTEGRA04/12 11,59
+17/06 PICPAY LBL INTEGRA04/12 46,13
+17/06 PICPAY LBL INTEGRA04/05 107,60 Simulação de Compras parc. c/ juros e
+17/06 PICPAY LBL INTEGRA04/06 20,39
+Crediário (próximo período)
+18/06 PICPAY LBL INTEGRA04/06 30,53
+18/06 PICPAY LBL INTEGRA04/06 57,01
+Juros da compra parcelada 5,99 % am 102,95% aa
+18/06 PICPAY LBL INTEGRA04/06 65,15
+CET da compra parcelada 6,32 % am 110,71 % aa
+05/07 RECARGAPAY LEONARD03/06 409,64
+% do total
+06/07 FARMACIA SAO JOAO 03/06 81,09
+Valor em R$ financiado
+07/07 RECARGAPAY LEONARD03/06 532,53
+Valor compra 500,00 97,02 %
+07/07 RECARGAPAY LEONARD03/06 532,53
+Valor do IOF 15,34 2,98 %
+07/07 RECARGAPAY LEONARD03/06 614,46
+Valor total financiado 515,34 100,00%
+07/07 RECARGAPAY LEONARD03/06 245,78
+Valor juros 477,06
+17/07 RECARGAPAY *LEONA03/06 25,60
+Quantidade de parcelas 24
+17/07 RECARGAPAY *LEONA03/06 102,41
+Valor da parcela 41,35
+17/07 RECARGAPAY *LEONA03/06 202,77
+Valor total a pagar 992,40
+Próxima fatura 3.437,73
+O valor do IOF compõe o valor financiado e será incluído nas
+Demais faturas 11.174,47
+parcelas.
+Total para próximas faturas 14.612,20
+Ao contratar esse produto, você declara que opagamento dos
+valores devidosnãocompromete suarendamínima existencial.
+Continua...
+Simulação Saque Cash
+Limite de saque 1.000,00
+Juros 17,00 % am 575,45% aa
+CET 21,23 % am 940,33% aa
+% do total
+Valor em R$ financiado
+Valor saque 500,00 99,38 %
+Valor do IOF 3,14 0,62 %
+Valor total financiado 503,14 100,00%
+Valor juros 85,00
+Valor tarifa 18,00
+Valor total a pagar 606,14
+Demais Taxas de Juros próximo período
+De retirada de recursos país 9,99 % am
+De pagamento de contas 6,99 % am 127,51 % aa
+PC - 00 01290 VK045 03/09/2024 VKRPOF01 G4205 0713185
+LEONARDO BROCKSTEDT LECH ,
+Pague sua fatura com a opção de parcelamento que melhor cabe no seu bolso!
+Oferta válida até o dia do vencimento da sua fatura. Sua taxa de juros de parcelamento é de 7,45% a.m. e 139,71% a.a.
+4 x de 6 x de 11 x de
+Sem seguro R$ 20.029,05 R$ 14.343,62 R$ 9.268,33
+Valor total financiado R$ 72.082,32 |100% R$ 72.272,91 |100% R$ 72.782,57 |100%
+Valor solicitado R$ 71.543,24 |99,25 % R$ 71.543,24 |98,99 % R$ 71.543,24 |98,30 %
+IOF R$ 539,08 |0,75 % R$ 729,67 |1,01 % R$ 1.239,33 |1,70 %
+CET 8,65 % a.m. - 174,39 % a.a. 8,50 % a.m. - 169,81 % a.a. 8,38 % a.m. - 166,20 % a.a.
+Total a pagar R$ 80.116,20 R$ 86.061,72 R$ 101.951,63
+Para contratar,pague o valor exato da parcela escolhida até o vencimento da fatura. Utilize o mesmo código de barras da fatura para
+efetuar o pagamento. Se preferir, simule outras opções no nosso app Itaú ou na Central de Atendimento.
+Importante: caso a sua fatura esteja em débito automático em uma instituição financeira diferente do Itaú, é necessário realizar o
+cancelamento desse serviço antes de contratar o Parcelamento de Fatura.
+O Parcelamento da Fatura tem incidência de encargos (juros e IOF) e inclui o valor total da fatura no momento da contratação. Outros valores como novas compras e parcelas a vencer, serão
+cobradas normalmente nas faturas seguintes. A contratação do parcelamento COM seguro é opcional e o valor do seguro será financiado utilizando a mesma taxa de juros, e será
+efetivada/formalizada com o pagamento da primeira parcela. O valor total do parcelamento comprometerá seu limite de crédito, que será recomposto à medida que as parcelas forem pagas.
+A simulação de qualquer opção em um de nossos outros canais, invalida as opções desta fatura.
+PC - 00 01290 VK045 03/09/2024 VKRPOF01 G4205 0713185

--- a/tests/data/Itau_2024-11.txt
+++ b/tests/data/Itau_2024-11.txt
@@ -1,0 +1,341 @@
+A992500005B
+PC -00
+LEONARDO BROCKSTEDT LECH
+Resumo da fatura em R$
+DOLOMITI 781
+101 - Planalto Total da fatura anterior 8.595,02
+55154800
+99250-000 Serafina Correa - RS
+Pagamento efetuado em 09/10/2024 - 8.595,02
+"ZVw#!
+S Saldo financiado 0,00
+Postagem: 03/11/2024 +
+L Lançamentos atuais 13.787,89
+Vencimento: 10/11/2024
+= Total desta fatura 13.787,89
+Emissão: 03/11/2024
+031124 Previsão prox. Fechamento: 03/12/2024
+Titular LEONARDO BROCKSTEDT LECH
+Cartão 5234.XXXX.XXXX.6853 MASTERCARD BLACK
+O total da sua fatura é: Com vencimento em: Limite total de crédito:
+R$ 13.787,89 10/11/2024 Flexível
+Preparamos outras opçõesdepagamento abaixo eaofinal dafatura, válidas atéadatadevencimento:
+Pagamento mínimo: Parcelas fixas:
+R$ 689,39 R$1.642,84
++ 10x R$ 1.642,84
+Valor em reais % do total financiado Valor em reais % do total financiado
+Valor total financiado R$ 13.098,50 100,00% Valor total financiado R$ 14.023,81 100,00%
+Encargos R$ 1.308,54 - Valor solicitado R$ 13.787,89 98,32 %
+IOF R$ 86,31 - IOF R$ 235,92 1,68 %
+Total a pagar R$ 15.182,74 - Total a pagar R$ 18.071,24 -
+Juros: 9,99 % am - 218,52 % aa CET: 10,62 % am - 241,29 % aa Juros: 5,45 % am - 90,72 % aa CET: 6,30 % am - 110,29 % aa
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 00000000000000 recibo do pagador
+Número do Documento 00406694061/0139781 Nosso Número 175/06694061-0
+Nome do Pagador/CPF/CNPJ LEONARDO BROCKSTEDT LECH - 024.244.030-40 Valor do Documento R$ 13.787,89
+Nome do Beneficiário/CPF/CNPJ ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23 Vencimento 10/11/2024
+Endereço do Beneficiário PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP Autenticação Mecânica
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 00000000000000
+Local de Pagamento Data de Vencimento
+Pague sua fatura em qualquer banco, mesmo após a data de vencimento. Dê preferência para o pagamento até a data de vencimento
+para não gerar encargos e/ou rescisão contratual. Em caso de atraso, os encargos serão cobrados na próxima fatura. 10/11/2024
+Nome do Beneficiário/ CNPJ/CPF/Endereço Agência / Código Beneficiário
+ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23
+PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP 2525/04345-7
+Data do Documento Número do Documento Espécie DOC. Aceite Data do Processamento Nosso Número
+10/11/2024 00406694061/0139781 FT N 03/11/2024 175/06694061-0
+Uso do Banco Carteira Espécie Quantidade Valor (=) Valor do Documento
+5/0 R$ R$ 13.787,89
+Instruções de responsabilidade do beneficiário. (-) Descontos / Abatimentos
+Indique o valor que deseja pagar no campo "Valor Pago". Dê preferência ao pagamento total. Não sendo possível, você terá as seguintes
+opções: (i) pagar quantia a partir do valor constante em Pagamento Mínimo , financiando o restante pelo crédito rotativo; (ii) optar por (+) Juros / Multa
+uma das opções de Parcelas Fixas , pagando o valor exato da parcela até a data do vencimento. O não pagamento poderá gerar
+inscrição nos órgãos restritivos de crédito. (=) Valor Pago
+Nome do Pagador/CPF/CNPJ/Endereço/Cidade/UF/CEP
+LEONARDO BROCKSTEDT LECH - 024.244.030-40
+<wwNnDNwONnNLwOnnWMNwITnnWI W7n8nn1W W- n1nnW0W1n n-nW PWlannnnWaWlntnnoW W- n9Nn9ww2N5Nn0Nw-w0nN0W0w n nSWewNrnannWfiNnwaNw CwnNonNrwrweNawN -w nRNwSnW -NnNNwnwNnWnwnnNWwnnWWn>
+Sacador Avalista:
+Autenticação Mecânica - Ficha de Compensação
+Caso você pague um valor entre o mínimo e o total de sua fatura, o saldo restante será cobrado na próxima fatura com juros e impostos. O pagamento
+do valor total é sempre a melhor opção porque não há cobranças de juros.
+O pagamento obrigatório é composto pelo saldo do crédito rotativo e respectivos encargos incidentes no período (R$ 0,00), prestações referentes a
+parcelamentos do saldo devedor de períodos anteriores (R$ 0,00) e valor mínimo de novas transações (R$ 689,39). Para entender mais sobre o
+pagamento obrigatório e o pagamento mínimo, acesse seu contrato e a aba "Serviços" no site Itaú Cartões.
+Consulte outras opções de parcelamento no final da sua fatura.
+Previsão do próximo fechamento: 03/12/2024.
+Lançamentos: compras e saques Lançamentos: compras e saques
+LEONARDO B LECH (final 6853) 04/10 APPLE.COM/BILL - 20,57
+DATA ESTABELECIMENTO VALOR EM R$ HOBBY .SAO PAULO
+28/05 FARMACIA SAO JOAO 06/06 39,40 06/10 REFUGIO SKATE PARK LTD 264,00
+SAÚDE .CAXIAS DO SUL ALIMENTAÇÃO .PASSO FUNDO
+10/06 FARMACIA SAO JOAO 05/06 87,64 06/10 APPLE.COM/BILL 69,90
+SAÚDE .PASSO FUNDO HOBBY .SAO PAULO
+06/07 FARMACIA SAO JOAO 04/06 81,09 07/10 BOURBON PASSO FUNDO 297,43
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .PASSO FUNDO
+27/09 FARMACIA SAO JOAO 02/04 20,78 07/10 PANVEL FARMACIAS 01/03 43,38
+SAÚDE .PASSO FUNDO SAÚDE .
+28/09 FARMACIA SAO JOAO 02/04 21,73 08/10 BOURBON PASSO FUNDO 319,24
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .PASSO FUNDO
+28/09 FARMACIA SAO JOAO - 0,09 09/10 IFD*ZANINI E MONTENEGR 96,11
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .Passo Fundo
+30/09 PANVEL FARMACIAS 02/03 42,70 10/10 FARMACIA SAO JOAO 82,89
+SAÚDE .PASSO FUNDO SAÚDE .PASSO FUNDO
+01/10 PANVEL FARMACIAS 02/03 127,05 10/10 PANVEL FARMACIAS 114,63
+SAÚDE .PASSO FUNDO SAÚDE .PASSO FUNDO
+01/10 PANVEL FARMACIAS - 0,04 11/10 APPLE.COM/BILL 124,90
+SAÚDE .PASSO FUNDO HOBBY .SAO PAULO
+03/10 IPLACE MOBILE 01/04 57,25 11/10 THE BOWLER SPORTS BAR 41,80
+VESTUÁRIO . ALIMENTAÇÃO .Passo Fundo
+03/10 FARMACIA SAO JOAO 01/06 67,08 11/10 REFUGIO SKATE PARK LTD 66,00
+SAÚDE . ALIMENTAÇÃO .PASSO FUNDO
+03/10 PASSO FUNDO SHOPPING 9,00 11/10 IFD*IFOOD CLUB 4,95
+VEÍCULOS .PASSO FUNDO ALIMENTAÇÃO .Osasco
+03/10 FARMACIA SAO JOAO - 0,05 11/10 IFD*ZANINI E MONTENEGR 87,50
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .Passo Fundo
+04/10 APPLE.COM/BILL 39,90 12/10 LEAL CENTER COMERCIO 79,80
+HOBBY .SAO PAULO ALIMENTAÇÃO .SOLEDADE
+04/10 PANVEL FARMACIAS 103,17 12/10 POSTOS TRADICAO 301,20
+SAÚDE .PASSO FUNDO VEÍCULOS .PASSO FUNDO
+Continua...
+3003 3030
+0800 720 3030
+PC - 00 01290 VK045 03/11/2024 VKRPOF01 G4267 0845155
+Lançamentos: compras e saques Lançamentos: compras e saques
+13/10 FARMACIA SAO JOAO 01/06 22,91 23/10 PADARIA E ROTISSERIA 23,00
+SAÚDE . ALIMENTAÇÃO .CAMPINAS
+14/10 PAQUETA 01/05 70,02 23/10 PADARIA E ROTISSERIA 79,00
+VESTUÁRIO . ALIMENTAÇÃO .CAMPINAS
+14/10 Administradora 9,00 24/10 JE LOGISTICA 6,00
+VEÍCULOS .PASSO FUNDO DIVERSOS .BRASILIA
+14/10 BOURBON PASSO FUNDO 463,37 24/10 JE LOGISTICA 6,00
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .BRASILIA
+14/10 IFD*HUKILAU RESTAURANT 70,00 24/10 JE LOGISTICA 4,00
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .BRASILIA
+15/10 AMMF COMERCIO DE A01/04 131,00 24/10 JE LOGISTICA 6,00
+ALIMENTAÇÃO . DIVERSOS .BRASILIA
+15/10 BARBEARIA INDEPENDENC 65,00 24/10 CONVENIENCIAS BRISAS 3,50
+DIVERSOS .PASSO FUNDO ALIMENTAÇÃO .BRASILIA
+15/10 FARMACIA SAO JOAO 25,80 24/10 VALORI *GEMELLI COZINH 172,00
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .BRASILIA
+15/10 ifood *IFD*MISO DELI 55,00 24/10 UBER* TRIP 22,17
+VEÍCULOS .Vila Yara Osa VEÍCULOS .OSASCO
+16/10 FARMACIA SAO JOAO 107,41 24/10 ZARA BRASIL 01/05 221,10
+SAÚDE .VERANOPOLIS VESTUÁRIO .
+16/10 STREET WEAR COMPAN01/10 65,97 24/10 UBER* TRIP 18,44
+VESTUÁRIO . VEÍCULOS .OSASCO
+16/10 REFUGIO SKATE PARK LTD 66,00 24/10 UBER* TRIP 41,63
+ALIMENTAÇÃO .PASSO FUNDO VEÍCULOS .OSASCO
+17/10 IFD*MISO DELIVERY LTDA 90,90 24/10 UBER* TRIP 30,61
+VEÍCULOS .PASSO FUNDO VEÍCULOS .OSASCO
+18/10 FARMACIA SAO JOAO 01/06 30,29 24/10 UBER* TRIP 45,16
+SAÚDE . VEÍCULOS .OSASCO
+19/10 STREET WEAR COMPAN01/10 49,99 25/10 APPLE.COM/BILL 49,90
+VESTUÁRIO . HOBBY .SAO PAULO
+19/10 REFUGIO SKATE PARK LTD 266,20 25/10 CONVENIENCIAS BRISAS 76,80
+ALIMENTAÇÃO .PASSO FUNDO ALIMENTAÇÃO .BRASILIA
+19/10 TAITZU 160,00 25/10 CONVENIENCIAS BRISAS 105,80
+ALIMENTAÇÃO .PASSO FUNDO ALIMENTAÇÃO .BRASILIA
+19/10 Deividifischer 1.782,00 25/10 JE LOGISTICA 4,00
+DIVERSOS .PASSO FUNDO DIVERSOS .BRASILIA
+19/10 FARMACIA SAO JOAO 01/06 78,52 25/10 CONVENIENCIAS BRISAS 57,00
+SAÚDE . ALIMENTAÇÃO .BRASILIA
+19/10 AUTO POSTO PETROPOLIS 419,01 25/10 UBER* TRIP 14,40
+VEÍCULOS .PASSO FUNDO VEÍCULOS .OSASCO
+19/10 BW SNACKS E BURGERS TA 41,00 25/10 UBER* TRIP 20,09
+ALIMENTAÇÃO .TAPEJARA VEÍCULOS .OSASCO
+19/10 IFD*MISO DELIVERY LTDA 65,00 26/10 CONVENIENCIAS BRISAS 114,90
+VEÍCULOS .PASSO FUNDO ALIMENTAÇÃO .BRASILIA
+19/10 IFD*ZANINI E MONTENEGR 92,10 26/10 CONVENIENCIAS BRISAS 91,50
+ALIMENTAÇÃO .Passo Fundo ALIMENTAÇÃO .BRASILIA
+20/10 AUTO POSTO PETROPOLIS 329,12 26/10 CONVENIENCIAS BRISAS 42,00
+VEÍCULOS .PASSO FUNDO ALIMENTAÇÃO .BRASILIA
+20/10 REFUGIO SKATE PARK LTD 316,80 27/10 UBER* TRIP 59,14
+ALIMENTAÇÃO .PASSO FUNDO VEÍCULOS .OSASCO
+20/10 APPLE.COM/BILL 399,90 Lançamentos no cartão (final 6853) 10.028,09
+HOBBY .SAO PAULO
+20/10 IFD*SANDRA MARIA GOSCH 64,90 LEONARDO B LECH (final 9779)
+ALIMENTAÇÃO .PASSO FUNDO DATA ESTABELECIMENTO VALOR EM R$
+20/10 IFD*SANDRA MARIA GOSCH 91,48 16/06 RECARGAPAY *LEONA05/12 18,28
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+22/10 BW SNACKS E BURGERS TA 41,00 16/06 RECARGAPAY *LEONA05/12 11,08
+ALIMENTAÇÃO .TAPEJARA DIVERSOS .SAO PAULO
+22/10 REFUGIO SKATE PARK LTD 32,60 16/06 RECARGAPAY *LEONA05/12 40,44
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+23/10 LIG AERO 01/05 57,98 16/06 RECARGAPAY *LEONA05/12 12,74
+DIVERSOS . DIVERSOS .SAO PAULO
+23/10 DROGASIL 2034 108,78 16/06 RECARGAPAY *LEONA05/12 20,50
+SAÚDE .LAGO SUL DIVERSOS .SAO PAULO
+23/10 CONVENIENCIAS BRISAS 170,70 16/06 RECARGAPAY *LEONA05/12 21,61
+ALIMENTAÇÃO .BRASILIA DIVERSOS .SAO PAULO
+23/10 CONVENIENCIAS BRISAS 77,90 16/06 RECARGAPAY *LEONA05/12 60,94
+ALIMENTAÇÃO .BRASILIA DIVERSOS .SAO PAULO
+23/10 IFD*DA SILVA SAGGIORA 78,49 16/06 RECARGAPAY *LEONA05/12 13,30
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+23/10 UBER* TRIP 48,04 16/06 RECARGAPAY *LEONA05/12 14,96
+VEÍCULOS .OSASCO DIVERSOS .SAO PAULO
+Continua...
+Lançamentos: compras e saques Compras parceladas - próximas faturas
+16/06 RECARGAPAY *LEONA05/12 11,63 18/06 PICPAY LBL INTEGRA06/06 30,53
+DIVERSOS .SAO PAULO 18/06 PICPAY LBL INTEGRA06/06 57,01
+Lançamentos no cartão (final 9779) 225,48 18/06 PICPAY LBL INTEGRA06/06 65,15
+05/07 RECARGAPAY LEONARD05/06 409,64
+LEONARDO B LECH (final 9835) 06/07 FARMACIA SAO JOAO 05/06 81,09
+DATA ESTABELECIMENTO VALOR EM R$ 07/07 RECARGAPAY LEONARD05/06 532,53
+17/06 PICPAY LBL INTEGRA05/12 11,59 07/07 RECARGAPAY LEONARD05/06 532,53
+DIVERSOS .S o Paulo 07/07 RECARGAPAY LEONARD05/06 614,46
+17/06 PICPAY LBL INTEGRA05/12 46,13 07/07 RECARGAPAY LEONARD05/06 245,78
+DIVERSOS .S o Paulo 17/07 RECARGAPAY *LEONA05/06 25,60
+17/06 PICPAY LBL INTEGRA05/05 107,60 17/07 RECARGAPAY *LEONA05/06 102,41
+DIVERSOS .S o Paulo 17/07 RECARGAPAY *LEONA05/06 202,77
+17/06 PICPAY LBL INTEGRA05/06 20,39 27/09 FARMACIA SAO JOAO 03/04 20,78
+DIVERSOS .S o Paulo 28/09 FARMACIA SAO JOAO 03/04 21,73
+18/06 PICPAY LBL INTEGRA05/06 30,53 30/09 PANVEL FARMACIAS 03/03 42,70
+DIVERSOS .S o Paulo 01/10 PANVEL FARMACIAS 03/03 127,05
+18/06 PICPAY LBL INTEGRA05/06 57,01 03/10 IPLACE MOBILE 02/04 57,25
+DIVERSOS .S o Paulo 03/10 FARMACIA SAO JOAO 02/06 67,08
+18/06 PICPAY LBL INTEGRA05/06 65,15 07/10 PANVEL FARMACIAS 02/03 43,38
+DIVERSOS .S o Paulo 13/10 FARMACIA SAO JOAO 02/06 22,91
+Lançamentos no cartão (final 9835) 338,40 14/10 PAQUETA 02/05 70,02
+15/10 AMMF COMERCIO DE A02/04 131,00
+16/10 STREET WEAR COMPAN02/10 65,97
+LEONARDO B LECH (final 3549)
+18/10 FARMACIA SAO JOAO 02/06 30,29
+DATA ESTABELECIMENTO VALOR EM R$
+19/10 STREET WEAR COMPAN02/10 49,99
+05/07 RECARGAPAY LEONARD04/06 409,64
+19/10 FARMACIA SAO JOAO 02/06 78,52
+DIVERSOS .SAO PAULO
+23/10 LIG AERO 02/05 57,98
+07/07 RECARGAPAY LEONARD04/06 532,53
+24/10 ZARA BRASIL 02/05 221,10
+DIVERSOS .SAO PAULO
+Próxima fatura 4.398,48
+07/07 RECARGAPAY LEONARD04/06 532,53
+Demais faturas 7.678,58
+DIVERSOS .SAO PAULO
+Total para próximas faturas 12.077,06
+07/07 RECARGAPAY LEONARD04/06 614,46
+DIVERSOS .SAO PAULO
+07/07 RECARGAPAY LEONARD04/06 245,78
+DIVERSOS .SAO PAULO Limites de crédito Valor em R$
+17/07 RECARGAPAY *LEONA04/06 25,60
+DIVERSOS .SAO PAULO Limite total de crédito Flexível
+17/07 RECARGAPAY *LEONA04/06 102,41 Limite total utilizado 25.535,58
+DIVERSOS .SAO PAULO
+17/07 RECARGAPAY *LEONA04/06 202,77 Limite máximo para saque no Brasil 1.000,00
+DIVERSOS .SAO PAULO Limite máximo para saque no exterior 7.000,00
+03/10 DM*Spotify 219,00
+DIVERSOS .SAO PAULO O limite total de crédito é composto pelos limites de saque.
+08/10 SUPERFORCE PASSO FUND 267,30 Esses são os seus limites na data de fechamento dessa fatura. Caso
+queira consultar informações atualizadas sobre o seu limite, consulte
+HOBBY .PASSO FUNDO
+nossos canais.
+Lançamentos no cartão (final 3549) 3.152,02
+LEONARDO B LECH (final 1462)
+DATA ESTABELECIMENTO VALOR EM R$ Encargos cobrados nesta fatura
+04/10 Disney Plus 43,90 Juros do rotativo 10,32 % 0,00
+DIVERSOS .SAO PAULO Juros de mora 1,00 % am 0,00
+Lançamentos no cartão (final 1462) 43,90 Multa por atraso 2,00 % 0,00
+IOF de financiamento (0,38 % + 0,00820 % a.d.) 0,00
+L Total dos lançamentos atuais 13.787,89
+Fique atento aos encargos para o próximo
+Compras parceladas - próximas faturas
+período (10/11 a 09/12)
+DATA ESTABELECIMENTO VALOR EM R$
+10/06 FARMACIA SAO JOAO 06/06 87,64
+Juros Máximos do contrato 9,99 % am 218,52 % aa
+16/06 RECARGAPAY *LEONA06/12 18,28
+16/06 RECARGAPAY *LEONA06/12 11,08
+16/06 RECARGAPAY *LEONA06/12 40,44
+16/06 RECARGAPAY *LEONA06/12 12,74
+16/06 RECARGAPAY *LEONA06/12 20,50
+16/06 RECARGAPAY *LEONA06/12 21,61
+16/06 RECARGAPAY *LEONA06/12 60,94
+16/06 RECARGAPAY *LEONA06/12 13,30
+16/06 RECARGAPAY *LEONA06/12 14,96
+16/06 RECARGAPAY *LEONA06/12 11,63
+17/06 PICPAY LBL INTEGRA06/12 11,59
+17/06 PICPAY LBL INTEGRA06/12 46,13
+17/06 PICPAY LBL INTEGRA06/06 20,39
+Continua...
+PC - 00 01290 VK045 03/11/2024 VKRPOF01 G4267 0845155
+Novo teto de juros do cartão de crédito
+Valor em R$
+Crédito Rotativo / Atraso
+Limite máximo de juros: R$ 0,00
+Juros e encargos financeiros até o momento: R$ 0,00
+% sobre o limite máximo de juros: 0,00 %
+Os juros e encargos que você irá pagar são os apresentados na
+contratação, e caso ultrapassem o limite máximo, a diferença não será
+cobrada ou será devolvida em fatura. Válido por cada operação de
+parcelamento ou rotativo.
+Simulação de Compras parc. c/ juros e
+Crediário (próximo período)
+Juros da compra parcelada 5,99 % am 102,95% aa
+CET da compra parcelada 6,32 % am 110,71 % aa
+% do total
+Valor em R$ financiado
+Valor compra 500,00 97,02 %
+Valor do IOF 15,34 2,98 %
+Valor total financiado 515,34 100,00%
+Valor juros 477,06
+Quantidade de parcelas 24
+Valor da parcela 41,35
+Valor total a pagar 992,40
+O valor do IOF compõe o valor financiado e será incluído nas
+parcelas.
+Ao contratar esse produto, você declara que opagamento dos
+valores devidosnãocompromete suarendamínima existencial.
+Simulação Saque Cash
+Limite de saque 1.000,00
+Juros 17,00 % am 575,45% aa
+CET 21,23 % am 940,33% aa
+% do total
+Valor em R$ financiado
+Valor saque 500,00 99,38 %
+Valor do IOF 3,14 0,62 %
+Valor total financiado 503,14 100,00%
+Valor juros 85,00
+Valor tarifa 18,00
+Valor total a pagar 606,14
+Demais Taxas de Juros próximo período
+De retirada de recursos país 9,99 % am
+De pagamento de contas 6,99 % am 127,51 % aa
+LEONARDO BROCKSTEDT LECH ,
+Pague sua fatura com a opção de parcelamento que melhor cabe no seu bolso!
+Oferta válida até o dia do vencimento da sua fatura. Sua taxa de juros de parcelamento é de 5,45% a.m. e 90,72% a.a.
+Novidade: você também pode contar com uma das opções com seguro e garantir a quitação total ou parcial do saldo devedor
+do parcelamento em caso de desemprego involuntário, incapacidade total, morte ou invalidez permanente total.
+4 x de 6 x de 8 x de
+Com seguro R$ 3.894,01 R$ 2.798,69 R$ 2.262,58
+Valor total financiado R$ 14.391,66 |100% R$ 14.749,62 |100% R$ 15.121,93 |100%
+Valor solicitado R$ 13.787,89 |95,81 % R$ 13.787,89 |93,48 % R$ 13.787,89 |91,18 %
+Seguro R$ 495,65 |3,44 % R$ 813,52 |5,52 % R$ 1.142,17 |7,55 %
+IOF R$ 108,12 |0,75 % R$ 148,21 |1,01 % R$ 191,87 |1,27 %
+CET 9,35 % a.m. - 196,68 % a.a. 9,12 % a.m. - 189,18 % a.a. 9,10 % a.m. - 188,54 % a.a.
+Total a pagar R$ 15.576,04 R$ 16.792,14 R$ 18.100,64
+4 x de 6 x de 8 x de
+Sem seguro R$ 3.758,89 R$ 2.642,76 R$ 2.089,49
+Valor total financiado R$ 13.892,26 |100% R$ 13.927,85 |100% R$ 13.965,09 |100%
+Valor solicitado R$ 13.787,89 |99,25 % R$ 13.787,89 |99,00 % R$ 13.787,89 |98,73 %
+IOF R$ 104,37 |0,75 % R$ 139,96 |1,01 % R$ 177,20 |1,27 %
+CET 6,63 % a.m. - 118,37 % a.a. 6,40 % a.m. - 112,71 % a.a. 6,32 % a.m. - 110,77 % a.a.
+Total a pagar R$ 15.035,56 R$ 15.856,56 R$ 16.715,92
+Para contratar,pague o valor exato da parcela escolhida até o vencimento da fatura. Utilize o mesmo código de barras da fatura para
+efetuar o pagamento. Se preferir, simule outras opções no nosso app Itaú ou na Central de Atendimento.
+Importante: caso a sua fatura esteja em débito automático em uma instituição financeira diferente do Itaú, é necessário realizar o
+cancelamento desse serviço antes de contratar o Parcelamento de Fatura.
+Opções com seguro: garantia de Perda Involuntária de Emprego (carência de 30 dias e franquia de 30 dias para registrados CLT há mais
+de 12 meses contínuos, com o mesmo empregador); incapacidade total e temporária (carência de 30 dias e franquia de 15 dias - este
+seguro é destinado a autônomos, com comprovação de recolhimento de contribuição por mais de 12 meses contínuos).
+Processo SUSEP n 15414.626445/2019-48. Seguradora: Itaú Seguros S.A., CNPJ: 61.557.039/0001-07. Estipulante: Itaú Unibanco Holding, CNPJ: 60.872.504/0001-23. Corretora: Itaú
+Corretora de Seguros S.A., CNPJ: 43.644.285/0001-06 - Registro SUSEP 20.203503-3. Este material possui breve descrição do produto. Para mais informações, consulte as Condições Gerais
+no site do cartão. A aceitação da proposta estará sujeita a análise do risco. O registro do produto é automático e não representa aprovação ou recomendação por parte da SUSEP. O segurado
+poderá consultar a situação cadastral do seu corretor de seguros no site: www.susep.gov.br , por meio do número do seu registro na SUSEP, nome completo, CNPJ ou CPF. Este seguro é por
+prazo determinado, pelo período do parcelamento de fatura contratado, tendo a seguradora a faculdade de não renovar a apólice na data de vencimento, sem devolução dos prêmios pagos
+nos termos da apólice.
+O Parcelamento da Fatura tem incidência de encargos (juros e IOF) e inclui o valor total da fatura no momento da contratação. Outros valores como novas compras e parcelas a vencer, serão
+cobradas normalmente nas faturas seguintes. A contratação do parcelamento COM seguro é opcional e o valor do seguro será financiado utilizando a mesma taxa de juros, e será
+efetivada/formalizada com o pagamento da primeira parcela. O valor total do parcelamento comprometerá seu limite de crédito, que será recomposto à medida que as parcelas forem pagas.
+A simulação de qualquer opção em um de nossos outros canais, invalida as opções desta fatura.
+PC - 00 01290 VK045 03/11/2024 VKRPOF01 G4267 0845155

--- a/tests/data/Itau_2024-12.txt
+++ b/tests/data/Itau_2024-12.txt
@@ -1,0 +1,374 @@
+A992500005B
+PC -00
+LEONARDO BROCKSTEDT LECH
+Resumo da fatura em R$
+DOLOMITI 781
+101 - Planalto Total da fatura anterior 13.787,89
+14367900
+99250-000 Serafina Correa - RS
+Pagamento efetuado em 08/11/2024 - 13.787,89
+"LbÖ#!
+S Saldo financiado 0,00
+Postagem: 09/12/2024 +
+L Lançamentos atuais 14.121,52
+Vencimento: 10/12/2024
+= Total desta fatura 14.121,52
+Emissão: 03/12/2024
+091224 Previsão prox. Fechamento: 03/01/2025
+Titular LEONARDO BROCKSTEDT LECH
+Cartão 5234.XXXX.XXXX.6853 MASTERCARD BLACK
+O total da sua fatura é: Com vencimento em: Limite total de crédito:
+R$ 14.121,52 10/12/2024 Flexível
+Preparamos outras opçõesdepagamento abaixo eaofinal dafatura, válidas atéadatadevencimento:
+Pagamento mínimo: Parcelas fixas:
+R$ 766,70 R$1.683,68
++ 10x R$ 1.683,68
+Valor em reais % do total financiado Valor em reais % do total financiado
+Valor total financiado R$ 13.354,82 100,00% Valor total financiado R$ 14.363,66 100,00%
+Encargos R$ 1.378,22 - Valor solicitado R$ 14.121,52 98,31 %
+IOF R$ 88,40 - IOF R$ 242,14 1,69 %
+Total a pagar R$ 15.588,14 - Total a pagar R$ 18.520,48 -
+Juros: 10,32 % am - 230,34 % aa CET: 10,95 % am - 253,88 % aa Juros: 5,45 % am - 90,72 % aa CET: 6,31 % am - 110,53 % aa
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 00000000000000 recibo do pagador
+Número do Documento 00406694061/0164596 Nosso Número 175/06694061-0
+Nome do Pagador/CPF/CNPJ LEONARDO BROCKSTEDT LECH - 024.244.030-40 Valor do Documento R$ 14.121,52
+Nome do Beneficiário/CPF/CNPJ ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23 Vencimento 10/12/2024
+Endereço do Beneficiário PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP Autenticação Mecânica
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Banco Itaú S.A. 341-7 34191.75066 69406.102520 50434.570003 4 00000000000000
+Local de Pagamento Data de Vencimento
+Pague sua fatura em qualquer banco, mesmo após a data de vencimento. Dê preferência para o pagamento até a data de vencimento
+para não gerar encargos e/ou rescisão contratual. Em caso de atraso, os encargos serão cobrados na próxima fatura. 10/12/2024
+Nome do Beneficiário/ CNPJ/CPF/Endereço Agência / Código Beneficiário
+ITAU UNIBANCO HOLDING S.A. - 60.872.504/0001-23
+PÇA ALFREDO EGYDIO DE S.ARANHA, 100,TOS 7 A, JABAQUARA - SÃO PAULO - SP 2525/04345-7
+Data do Documento Número do Documento Espécie DOC. Aceite Data do Processamento Nosso Número
+10/12/2024 00406694061/0164596 FT N 03/12/2024 175/06694061-0
+Uso do Banco Carteira Espécie Quantidade Valor (=) Valor do Documento
+5/0 R$ R$ 14.121,52
+Instruções de responsabilidade do beneficiário. (-) Descontos / Abatimentos
+Indique o valor que deseja pagar no campo "Valor Pago". Dê preferência ao pagamento total. Não sendo possível, você terá as seguintes
+opções: (i) pagar quantia a partir do valor constante em Pagamento Mínimo , financiando o restante pelo crédito rotativo; (ii) optar por (+) Juros / Multa
+uma das opções de Parcelas Fixas , pagando o valor exato da parcela até a data do vencimento. O não pagamento poderá gerar
+inscrição nos órgãos restritivos de crédito. (=) Valor Pago
+Nome do Pagador/CPF/CNPJ/Endereço/Cidade/UF/CEP
+LEONARDO BROCKSTEDT LECH - 024.244.030-40
+<wwNnDNwONnNLwOnnWMNwITnnWI W7n8nn1W W- n1nnW0W1n n-nW PWlannnnWaWlntnnoW W- n9Nn9ww2N5Nn0Nw-w0nN0W0w n nSWewNrnannWfiNnwaNw CwnNonNrwrweNawN -w nRNwSnW -NnNNwnwNnWnwnnNWwnnWWn>
+Sacador Avalista:
+Autenticação Mecânica - Ficha de Compensação
+Caso você pague um valor entre o mínimo e o total de sua fatura, o saldo restante será cobrado na próxima fatura com juros e impostos. O pagamento
+do valor total é sempre a melhor opção porque não há cobranças de juros.
+O pagamento obrigatório é composto pelo saldo do crédito rotativo e respectivos encargos incidentes no período (R$ 28,88), prestações referentes a
+parcelamentos do saldo devedor de períodos anteriores (R$ 0,00) e valor mínimo de novas transações (R$ 737,82). Para entender mais sobre o
+pagamento obrigatório e o pagamento mínimo, acesse seu contrato e a aba "Serviços" no site Itaú Cartões.
+Consulte outras opções de parcelamento no final da sua fatura.
+Previsão do próximo fechamento: 03/01/2025.
+Lançamentos: compras e saques Lançamentos: compras e saques
+LEONARDO B LECH (final 6853) 16/10 STREET WEAR COMPAN02/10 65,97
+DATA ESTABELECIMENTO VALOR EM R$ VESTUÁRIO .MARAU
+10/06 FARMACIA SAO JOAO 06/06 87,64 18/10 FARMACIA SAO JOAO 02/06 30,29
+SAÚDE .PASSO FUNDO SAÚDE .PASSO FUNDO
+06/07 FARMACIA SAO JOAO 05/06 81,09 18/10 FARMACIA SAO JOAO - 0,05
+SAÚDE .PASSO FUNDO SAÚDE .PASSO FUNDO
+27/09 FARMACIA SAO JOAO 03/04 20,78 19/10 STREET WEAR COMPAN02/10 49,99
+SAÚDE .PASSO FUNDO VESTUÁRIO .MARAU
+28/09 FARMACIA SAO JOAO 03/04 21,73 19/10 FARMACIA SAO JOAO 02/06 78,52
+SAÚDE .PASSO FUNDO SAÚDE .PASSO FUNDO
+30/09 PANVEL FARMACIAS 03/03 42,70 19/10 FARMACIA SAO JOAO - 0,25
+SAÚDE .PASSO FUNDO SAÚDE .PASSO FUNDO
+01/10 PANVEL FARMACIAS 03/03 127,05 23/10 LIG AERO 02/05 57,98
+SAÚDE .PASSO FUNDO DIVERSOS .BRASILIA
+03/10 IPLACE MOBILE 02/04 57,25 24/10 ZARA BRASIL 02/05 221,10
+VESTUÁRIO .PASSO FUNDO VESTUÁRIO .BRASILIA
+03/10 FARMACIA SAO JOAO 02/06 67,08 06/11 APPLE.COM/BILL 69,90
+SAÚDE .PASSO FUNDO HOBBY .SAO PAULO
+07/10 PANVEL FARMACIAS 02/03 43,38 10/11 APPLE.COM/BILL 55,90
+SAÚDE .PASSO FUNDO HOBBY .SAO PAULO
+07/10 PANVEL FARMACIAS - 0,02 11/11 IFD*IFOOD CLUB 4,95
+SAÚDE .PASSO FUNDO ALIMENTAÇÃO .Osasco
+13/10 FARMACIA SAO JOAO 02/06 22,91 11/11 PANVEL FARMACIAS 01/03 58,88
+SAÚDE .SOLEDADE SAÚDE .
+13/10 FARMACIA SAO JOAO - 0,05 12/11 BUFFON 25 312,82
+SAÚDE .SOLEDADE VEÍCULOS .PASSO FUNDO
+14/10 PAQUETA 02/05 70,02 12/11 IFD*MISO DELIVERY LTDA 75,00
+VESTUÁRIO .PASSO FUNDO VEÍCULOS .PASSO FUNDO
+14/10 PAQUETA - 0,12 13/11 FARMACIA SAO JOAO 01/06 44,78
+VESTUÁRIO .PASSO FUNDO SAÚDE .
+15/10 AMMF COMERCIO DE A02/04 131,00 13/11 IFD*DA SILVA SAGGIORA 68,49
+ALIMENTAÇÃO .PASSO FUNDO ALIMENTAÇÃO .PASSO FUNDO
+Continua...
+3003 3030
+0800 720 3030
+PC - 00 01290 VK045 09/12/2024 VKRPOF01 G4302 0976341
+Lançamentos: compras e saques Lançamentos: compras e saques
+14/11 RESTAURANTE FRANZ 82,37 02/12 FARMACIA SAO JOAO 01/06 20,39
+ALIMENTAÇÃO .PASSO FUNDO SAÚDE .
+14/11 BW SNACKS E BURGERS TA 41,00 Lançamentos no cartão (final 6853) 8.438,82
+ALIMENTAÇÃO .TAPEJARA
+15/11 REFUGIO SKATE PARK LTD 222,20 LEONARDO B LECH (final 9779)
+ALIMENTAÇÃO .PASSO FUNDO DATA ESTABELECIMENTO VALOR EM R$
+15/11 BOURBON PASSO FUNDO 229,82 16/06 RECARGAPAY *LEONA06/12 18,28
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+15/11 REFUGIO SKATE PARK LTD 169,40 16/06 RECARGAPAY *LEONA06/12 11,08
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+16/11 INSIDER COME*Insid01/03 54,42 16/06 RECARGAPAY *LEONA06/12 40,44
+VESTUÁRIO . DIVERSOS .SAO PAULO
+16/11 PANVEL FARMACIAS 01/03 43,54 16/06 RECARGAPAY *LEONA06/12 12,74
+SAÚDE . DIVERSOS .SAO PAULO
+17/11 REFUGIO SKATE PARK LTD 425,70 16/06 RECARGAPAY *LEONA06/12 20,50
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+17/11 LANCHES 2.050,00 16/06 RECARGAPAY *LEONA06/12 21,61
+DIVERSOS .So Jos dos P DIVERSOS .SAO PAULO
+17/11 OFICINA MECANICA 149,00 16/06 RECARGAPAY *LEONA06/12 60,94
+TURISMO E ENTRETENIM.PASSO FUNDO DIVERSOS .SAO PAULO
+18/11 FARMACIA SAO JOAO 113,90 16/06 RECARGAPAY *LEONA06/12 13,30
+SAÚDE .PASSO FUNDO DIVERSOS .SAO PAULO
+19/11 BOURBON PASSO FUNDO 136,96 16/06 RECARGAPAY *LEONA06/12 14,96
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+19/11 ANDRE RENATO BOLNER LT 34,00 16/06 RECARGAPAY *LEONA06/12 11,63
+ALIMENTAÇÃO .PASSO FUNDO DIVERSOS .SAO PAULO
+19/11 IFD*MISO DELIVERY LTDA 55,00 Lançamentos no cartão (final 9779) 225,48
+VEÍCULOS .PASSO FUNDO
+20/11 BARBEARIA INDEPENDENC 100,00
+LEONARDO B LECH (final 9835)
+DIVERSOS .PASSO FUNDO
+DATA ESTABELECIMENTO VALOR EM R$
+20/11 IFD*PIZZARIA INDEPENDE 96,40
+17/06 PICPAY LBL INTEGRA06/12 11,59
+ALIMENTAÇÃO .PASSO FUNDO
+DIVERSOS .S o Paulo
+21/11 KYLANCHES 5,00
+17/06 PICPAY LBL INTEGRA06/12 46,13
+ALIMENTAÇÃO .PORTO ALEGRE
+DIVERSOS .S o Paulo
+21/11 PANVEL FARMACIAS 114,63
+17/06 PICPAY LBL INTEGRA06/06 20,39
+SAÚDE .PASSO FUNDO
+DIVERSOS .S o Paulo
+23/11 ITALIAN S 23,00
+18/06 PICPAY LBL INTEGRA06/06 30,53
+ALIMENTAÇÃO .Soledade
+DIVERSOS .S o Paulo
+23/11 REFUGIO SKATE PARK LTD 20,00
+18/06 PICPAY LBL INTEGRA06/06 57,01
+ALIMENTAÇÃO .PASSO FUNDO
+DIVERSOS .S o Paulo
+24/11 REFUGIO SKATE PARK LTD 255,20
+18/06 PICPAY LBL INTEGRA06/06 65,15
+ALIMENTAÇÃO .PASSO FUNDO
+DIVERSOS .S o Paulo
+24/11 FARMACIA SAO JOAO 01/06 22,65
+Lançamentos no cartão (final 9835) 230,80
+SAÚDE .
+24/11 IFD*54.124.928 PALOMA 56,97
+LEONARDO B LECH (final 3549)
+ALIMENTAÇÃO .PASSO FUNDO
+25/11 APPLE.COM/BILL 49,90 DATA ESTABELECIMENTO VALOR EM R$
+05/07 RECARGAPAY LEONARD05/06 409,64
+HOBBY .SAO PAULO
+25/11 PANVEL FARMACIAS 248,61 DIVERSOS .SAO PAULO
+07/07 RECARGAPAY LEONARD05/06 532,53
+SAÚDE .PASSO FUNDO
+25/11 PANVEL FARMACIAS 387,21 DIVERSOS .SAO PAULO
+07/07 RECARGAPAY LEONARD05/06 532,53
+SAÚDE .PASSO FUNDO
+25/11 PANVEL FARMACIAS 129,07 DIVERSOS .SAO PAULO
+07/07 RECARGAPAY LEONARD05/06 614,46
+SAÚDE .PASSO FUNDO
+26/11 BOURBON PASSO FUNDO 98,66 DIVERSOS .SAO PAULO
+07/07 RECARGAPAY LEONARD05/06 245,78
+ALIMENTAÇÃO .PASSO FUNDO
+26/11 BUFFON 25 283,72 DIVERSOS .SAO PAULO
+17/07 RECARGAPAY *LEONA05/06 25,60
+VEÍCULOS .PASSO FUNDO
+26/11 PANVEL FARMACIAS 99,99 DIVERSOS .SAO PAULO
+17/07 RECARGAPAY *LEONA05/06 102,41
+SAÚDE .PASSO FUNDO
+27/11 PANVEL FARMACIAS 114,63 DIVERSOS .SAO PAULO
+17/07 RECARGAPAY *LEONA05/06 202,77
+SAÚDE .PASSO FUNDO
+28/11 PANVEL FARMACIAS 01/03 38,21 DIVERSOS .SAO PAULO
+15/11 Disney Plus 43,90
+SAÚDE .
+01/12 AUTO POSTO PETROPOLIS 23,73 DIVERSOS .SAO PAULO
+19/11 VIACAO OURO E PRAT01/03 37,89
+VEÍCULOS .PASSO FUNDO
+01/12 IFD*44.164.938 ALINE R 150,99 VEÍCULOS .
+25/11 MERCADOLIVRE*ESTOCK99 187,06
+ALIMENTAÇÃO .PASSO FUNDO
+02/12 BUFFON 25 15,98 VESTUÁRIO .Osasco
+25/11 MERCADOLIVRE*ARMAZEMB 86,24
+VEÍCULOS .PASSO FUNDO
+02/12 BUFFON 25 309,86 ALIMENTAÇÃO .Osasco
+VEÍCULOS .PASSO FUNDO
+Continua...
+Lançamentos: compras e saques Compras parceladas - próximas faturas
+25/11 MERCADOLIVRE*MSTORECA 143,45 06/07 FARMACIA SAO JOAO 06/06 81,09
+DIVERSOS .Osasco 07/07 RECARGAPAY LEONARD06/06 532,53
+27/11 MP *OCEANDROP 01/06 64,70 07/07 RECARGAPAY LEONARD06/06 532,53
+ALIMENTAÇÃO . 07/07 RECARGAPAY LEONARD06/06 614,46
+01/12 BMB*SEANET RS 150,00 07/07 RECARGAPAY LEONARD06/06 245,78
+DIVERSOS .CARAZINHO 17/07 RECARGAPAY *LEONA06/06 25,60
+02/12 INSIDER COME*Insid01/04 139,27 17/07 RECARGAPAY *LEONA06/06 102,41
+VESTUÁRIO . 17/07 RECARGAPAY *LEONA06/06 202,77
+Lançamentos no cartão (final 3549) 3.518,23 27/09 FARMACIA SAO JOAO 04/04 20,78
+28/09 FARMACIA SAO JOAO 04/04 21,73
+Lançamentos internacionais 03/10 IPLACE MOBILE 03/04 57,25
+03/10 FARMACIA SAO JOAO 03/06 67,08
+LEONARDO B LECH (final 6853)
+07/10 PANVEL FARMACIAS 03/03 43,38
+DATA ESTABELECIMENTO US$ R$
+13/10 FARMACIA SAO JOAO 03/06 22,91
+28/11 VOCALIMAGE.APP 31,59
+14/10 PAQUETA 03/05 70,02
+TALLINN 4,99 USD 4,99
+15/10 AMMF COMERCIO DE A03/04 131,00
+Dólar de Conversão R$ 6,33
+16/10 STREET WEAR COMPAN03/10 65,97
+30/11 SUNO INC. 38,40
+18/10 FARMACIA SAO JOAO 03/06 30,29
+CAMBRIDGE 6,00 USD 6,00
+19/10 STREET WEAR COMPAN03/10 49,99
+Dólar de Conversão R$ 6,40
+19/10 FARMACIA SAO JOAO 03/06 78,52
+Total transações inter. em R$ 69,99
+23/10 LIG AERO 03/05 57,98
+Repasse de IOF em R$ 3,05
+24/10 ZARA BRASIL 03/05 221,10
+Total lançamentos inter. em R$ 73,04
+11/11 PANVEL FARMACIAS 02/03 58,88
+13/11 FARMACIA SAO JOAO 02/06 44,78
+LEONARDO B LECH (final 3549) 16/11 INSIDER COME*Insid02/03 54,42
+DATA ESTABELECIMENTO US$ R$ 16/11 PANVEL FARMACIAS 02/03 43,54
+25/11 OZANPA *premiumtr.com 183,90 19/11 VIACAO OURO E PRAT02/03 37,89
+ADANA 30,00 USD 30,00 24/11 FARMACIA SAO JOAO 02/06 22,65
+Dólar de Conversão R$ 6,13 26/11 BOLETO PARCELADO 02/06 34,94
+25/11 OZANPA *premiumtr.com 122,60 27/11 MP *OCEANDROP 02/06 64,70
+ADANA 20,00 USD 20,00 28/11 PANVEL FARMACIAS 02/03 38,21
+Dólar de Conversão R$ 6,13 02/12 FARMACIA SAO JOAO 02/06 20,39
+Total transações inter. em R$ 306,50 02/12 INSIDER COME*Insid02/04 139,27
+Repasse de IOF em R$ 13,42 Próxima fatura 4.527,68
+Total lançamentos inter. em R$ 319,92 Demais faturas 4.971,89
+Total para próximas faturas 9.499,57
+Lançamentos: produtos e serviços
+DATA PRODUTOS/SERVIÇOS VALOR EM R$
+22/11 PAGTO CONTA TITULOS 987,45 Limites de crédito Valor em R$
+22/11 JUROS PAGAMENTO CONTAS 23,65 Limite total de crédito Flexível
+Limite total utilizado 23.065,31
+23/11 IOF PAGAMENTO CONTAS 5,23
+0,53 % do total financiado
+Limite máximo para saque no Brasil 1.000,00
+26/11 BOLETO PARCELADO 01/06 34,94
+Limite máximo para saque no exterior 7.000,00
+Principal (R$ 32,28 ) + Juros (R$ 2,66 )
+Lançamentos produtos e serviços 1.051,27
+O limite total de crédito é composto pelos limites de saque.
+Esses são os seus limites na data de fechamento dessa fatura. Caso
+Outros lançamentos queira consultar informações atualizadas sobre o seu limite, consulte
+nossos canais.
+DATA DESCRIÇÃO VALOR EM R$
+05/11 ACELERADOR DE PONTOS 263,96
+Total de outros lançamentos 263,96
+Encargos cobrados nesta fatura
+Juros do rotativo 9,99 % 0,00
+L Total dos lançamentos atuais 14.121,52 Juros de mora 1,00 % am 0,00
+Multa por atraso 2,00 % 0,00
+Compras parceladas - próximas faturas IOF de financiamento (0,38 % + 0,00820 % a.d.) 0,00
+DATA ESTABELECIMENTO VALOR EM R$
+16/06 RECARGAPAY *LEONA07/12 18,28
+16/06 RECARGAPAY *LEONA07/12 11,08 Fique atento aos encargos para o próximo
+16/06 RECARGAPAY *LEONA07/12 40,44
+período (10/12 a 09/01)
+16/06 RECARGAPAY *LEONA07/12 12,74
+16/06 RECARGAPAY *LEONA07/12 20,50
+Juros Máximos do contrato 10,32 % am 230,34 % aa
+16/06 RECARGAPAY *LEONA07/12 21,61
+16/06 RECARGAPAY *LEONA07/12 60,94
+16/06 RECARGAPAY *LEONA07/12 13,30
+16/06 RECARGAPAY *LEONA07/12 14,96
+16/06 RECARGAPAY *LEONA07/12 11,63
+17/06 PICPAY LBL INTEGRA07/12 11,59
+17/06 PICPAY LBL INTEGRA07/12 46,13
+05/07 RECARGAPAY LEONARD06/06 409,64
+Continua...
+PC - 00 01290 VK045 09/12/2024 VKRPOF01 G4302 0976341
+Novo teto de juros do cartão de crédito
+Valor em R$
+Crédito Rotativo / Atraso
+Limite máximo de juros: R$ 0,00
+Juros e encargos financeiros até o momento: R$ 0,00
+% sobre o limite máximo de juros: 0,00 %
+Os juros e encargos que você irá pagar são os apresentados na
+contratação, e caso ultrapassem o limite máximo, a diferença não será
+cobrada ou será devolvida em fatura. Válido por cada operação de
+parcelamento ou rotativo.
+Simulação de Compras parc. c/ juros e
+Crediário (próximo período)
+Juros da compra parcelada 5,99 % am 102,95% aa
+CET da compra parcelada 6,32 % am 110,71 % aa
+% do total
+Valor em R$ financiado
+Valor compra 500,00 97,02 %
+Valor do IOF 15,34 2,98 %
+Valor total financiado 515,34 100,00%
+Valor juros 477,06
+Quantidade de parcelas 24
+Valor da parcela 41,35
+Valor total a pagar 992,40
+O valor do IOF compõe o valor financiado e será incluído nas
+parcelas.
+Ao contratar esse produto, você declara que opagamento dos
+valores devidosnãocompromete suarendamínima existencial.
+Simulação Saque Cash
+Limite de saque 1.000,00
+Juros 17,00 % am 575,45% aa
+CET 21,23 % am 940,33% aa
+% do total
+Valor em R$ financiado
+Valor saque 500,00 99,38 %
+Valor do IOF 3,14 0,62 %
+Valor total financiado 503,14 100,00%
+Valor juros 85,00
+Valor tarifa 18,00
+Valor total a pagar 606,14
+Demais Taxas de Juros próximo período
+De retirada de recursos país 10,32 % am
+De pagamento de contas 6,99 % am 127,51 % aa
+LEONARDO BROCKSTEDT LECH ,
+Pague sua fatura com a opção de parcelamento que melhor cabe no seu bolso!
+Oferta válida até o dia do vencimento da sua fatura. Sua taxa de juros de parcelamento é de 5,45% a.m. e 90,72% a.a.
+Novidade: você também pode contar com uma das opções com seguro e garantir a quitação total ou parcial do saldo devedor
+do parcelamento em caso de desemprego involuntário, incapacidade total, morte ou invalidez permanente total.
+4 x de 6 x de 8 x de
+Com seguro R$ 3.985,51 R$ 2.867,37 R$ 2.318,41
+Valor total financiado R$ 14.728,82 |100% R$ 15.106,77 |100% R$ 15.488,20 |100%
+Valor solicitado R$ 14.121,52 |95,88 % R$ 14.121,52 |93,48 % R$ 14.121,52 |91,18 %
+Seguro R$ 496,60 |3,37 % R$ 833,21 |5,52 % R$ 1.169,80 |7,55 %
+IOF R$ 110,70 |0,75 % R$ 152,04 |1,01 % R$ 196,88 |1,27 %
+CET 9,30 % a.m. - 195,04 % a.a. 9,13 % a.m. - 189,50 % a.a. 9,12 % a.m. - 189,18 % a.a.
+Total a pagar R$ 15.942,04 R$ 17.204,22 R$ 18.547,28
+4 x de 6 x de 8 x de
+Sem seguro R$ 3.850,11 R$ 2.707,61 R$ 2.141,05
+Valor total financiado R$ 14.228,46 |100% R$ 14.265,09 |100% R$ 14.303,34 |100%
+Valor solicitado R$ 14.121,52 |99,25 % R$ 14.121,52 |98,99 % R$ 14.121,52 |98,73 %
+IOF R$ 106,94 |0,75 % R$ 143,57 |1,01 % R$ 181,82 |1,27 %
+CET 6,64 % a.m. - 118,62 % a.a. 6,41 % a.m. - 112,95 % a.a. 6,34 % a.m. - 111,26 % a.a.
+Total a pagar R$ 15.400,44 R$ 16.245,66 R$ 17.128,40
+Para contratar,pague o valor exato da parcela escolhida até o vencimento da fatura. Utilize o mesmo código de barras da fatura para
+efetuar o pagamento. Se preferir, simule outras opções no nosso app Itaú ou na Central de Atendimento.
+Importante: caso a sua fatura esteja em débito automático em uma instituição financeira diferente do Itaú, é necessário realizar o
+cancelamento desse serviço antes de contratar o Parcelamento de Fatura.
+Opções com seguro: garantia de Perda Involuntária de Emprego (carência de 30 dias e franquia de 30 dias para registrados CLT há mais
+de 12 meses contínuos, com o mesmo empregador); incapacidade total e temporária (carência de 30 dias e franquia de 15 dias - este
+seguro é destinado a autônomos, com comprovação de recolhimento de contribuição por mais de 12 meses contínuos).
+Processo SUSEP n 15414.626445/2019-48. Seguradora: Itaú Seguros S.A., CNPJ: 61.557.039/0001-07. Estipulante: Itaú Unibanco Holding, CNPJ: 60.872.504/0001-23. Corretora: Itaú
+Corretora de Seguros S.A., CNPJ: 43.644.285/0001-06 - Registro SUSEP 20.203503-3. Este material possui breve descrição do produto. Para mais informações, consulte as Condições Gerais
+no site do cartão. A aceitação da proposta estará sujeita a análise do risco. O registro do produto é automático e não representa aprovação ou recomendação por parte da SUSEP. O segurado
+poderá consultar a situação cadastral do seu corretor de seguros no site: www.susep.gov.br , por meio do número do seu registro na SUSEP, nome completo, CNPJ ou CPF. Este seguro é por
+prazo determinado, pelo período do parcelamento de fatura contratado, tendo a seguradora a faculdade de não renovar a apólice na data de vencimento, sem devolução dos prêmios pagos
+nos termos da apólice.
+O Parcelamento da Fatura tem incidência de encargos (juros e IOF) e inclui o valor total da fatura no momento da contratação. Outros valores como novas compras e parcelas a vencer, serão
+cobradas normalmente nas faturas seguintes. A contratação do parcelamento COM seguro é opcional e o valor do seguro será financiado utilizando a mesma taxa de juros, e será
+efetivada/formalizada com o pagamento da primeira parcela. O valor total do parcelamento comprometerá seu limite de crédito, que será recomposto à medida que as parcelas forem pagas.
+A simulação de qualquer opção em um de nossos outros canais, invalida as opções desta fatura.
+PC - 00 01290 VK045 09/12/2024 VKRPOF01 G4302 0976341


### PR DESCRIPTION
## Summary
- snapshot PDF text under `tests/data/*.txt`
- write snapshots from `check_accuracy.py` when available
- streamline `test_validation` to use snapshots or pdfplumber

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ef4ee8e88327b5f973669f77bf3d