### PR TITLE
Upload coverage artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,13 @@ jobs:
         with:
           files: coverage.xml
 
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
 
       - name: Check parser accuracy
         if: always()


### PR DESCRIPTION
## Summary
- upload coverage.xml as an artifact
- ensure the CI uses `--cov-report=xml` and `--cov-fail-under=90` for coverage
- verify `pytest-cov` exists in the dev extras

## Testing
- `pytest -q` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef4df23c83279913b9e9e88b936f