### PR TITLE
Improve parser accuracy enforcement

### DIFF
--- a/.github/tools/evolve.py
+++ b/.github/tools/evolve.py
@@ -103,6 +103,12 @@ def run_tests() -> Tuple[bool, float]:
             "--cov-report=term-missing",
             capture=True,
         )
+        sh(
+            "python",
+            "scripts/check_accuracy.py",
+            "--threshold",
+            "99",
+        )
     except subprocess.CalledProcessError:
         return False, 0.0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,10 +106,18 @@ jobs:
                  --cov-report=term-missing --cov-report=xml \
                  --cov-fail-under=90
 
+      - name: Check parser accuracy
+        id: accuracy
+        continue-on-error: true
+        run: python scripts/check_accuracy.py --threshold 99
+
       # auto-patch loop if tests failed or FORCE_EVOLVE=1
       - name: Evolve patch loop
         id: evolve
-        if: steps.tests.outcome == 'failure' || env.FORCE_EVOLVE == '1'
+        if: |
+          steps.tests.outcome == 'failure' ||
+          steps.accuracy.outcome == 'failure' ||
+          env.FORCE_EVOLVE == '1'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
@@ -134,6 +142,10 @@ jobs:
           pytest -ra -vv --cov=statement_refinery \
                  --cov-report=term-missing --cov-report=xml \
                  --cov-fail-under=90
+
+      - name: Re-check parser accuracy
+        if: always()
+        run: python scripts/check_accuracy.py --threshold 99
 
       - name: Upload coverage
         if: always()

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ files within it.
 
 ## Checking Parser Accuracy
 
-Run `scripts/check_accuracy.py` to compare the parser output with any golden files:
+Run `scripts/check_accuracy.py` to compare the parser output with any golden files.
+The script fails if the average match percentage falls below the threshold (99%
+by default):
 
-    python scripts/check_accuracy.py
+    python scripts/check_accuracy.py --threshold 99
 
 The tool runs `pdf_to_csv.main()` for each PDF in `tests/data/` and reports diffs and a match percentage.
 

--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -1,8 +1,10 @@
 import io
 import contextlib
+import argparse
 from pathlib import Path
 import difflib
 import importlib.util
+import statistics
 import sys, os  # noqa: E401,F401
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,10 +18,10 @@ from statement_refinery import pdf_to_csv  # noqa: E402
 DATA_DIR = ROOT / "tests" / "data"
 
 
-def compare(pdf_path: Path) -> bool:
+def compare(pdf_path: Path) -> tuple[bool, float]:
     """Run pdf_to_csv on *pdf_path* and compare to its golden CSV.
 
-    Returns ``True`` if a mismatch is found.
+    Returns ``(mismatch, percentage)``.
     """
     print(f"\n=== {pdf_path.name} ===")
     buf = io.StringIO()
@@ -34,7 +36,7 @@ def compare(pdf_path: Path) -> bool:
             txt = pdf_path.with_suffix(".txt")
             if not txt.exists():
                 print("Fallback text file missing. Skipping.")
-                return False
+                return False, 0.0
             lines = txt.read_text().splitlines()
             rows = pdf_to_csv.parse_lines(iter(lines))
             pdf_to_csv.write_csv(rows, buf)
@@ -43,7 +45,7 @@ def compare(pdf_path: Path) -> bool:
     golden = pdf_path.with_name(f"golden_{pdf_path.stem.split('_')[-1]}.csv")
     if not golden.exists():
         print("No golden CSV found. Skipping diff.")
-        return
+        return False, 100.0
 
     golden_lines = golden.read_text().splitlines()
     diff = difflib.unified_diff(
@@ -63,22 +65,40 @@ def compare(pdf_path: Path) -> bool:
     matcher = difflib.SequenceMatcher(None, golden_lines, output_lines)
     pct = matcher.ratio() * 100
     print(f"Match percentage: {pct:.2f}%")
-    return mismatch
+    return mismatch, pct
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=99.0,
+        help="fail if average match percentage is below this value",
+    )
+    args = parser.parse_args()
+
     pdfs = sorted(DATA_DIR.glob("itau_*.pdf"))
     if not pdfs:
         print("No PDFs found in tests/data.")
         return
 
     mismatched = False
+    percentages = []
     for pdf in pdfs:
-        if compare(pdf):
+        mis, pct = compare(pdf)
+        percentages.append(pct)
+        if mis:
             mismatched = True
 
+    avg = statistics.mean(percentages) if percentages else 0.0
+    print(f"Average match across PDFs: {avg:.2f}%")
+    if avg < args.threshold:
+        print(f"Accuracy {avg:.2f}% below threshold {args.threshold}%")
+        mismatched = True
+
     if mismatched:
-        raise SystemExit("mismatched parser output")
+        raise SystemExit("mismatched parser output or low accuracy")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce a 99% accuracy threshold in `scripts/check_accuracy.py`
- integrate accuracy check into `evolve.py` scoring
- run the accuracy check in CI to trigger the Codex patch loop when accuracy drops
- document the new threshold option in the README

## Testing
- `ruff check .`
- `black --check .`
- `pytest -ra -vv --cov=statement_refinery --cov-report=term-missing --cov-report=xml --cov-fail-under=90`
- `python scripts/check_accuracy.py --threshold 99`


------
https://chatgpt.com/codex/tasks/task_e_6841fba06ad483279db8fed8cd1f2468