### PR TITLE
Fix YAML syntax in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Evolve skipped
         if: steps.evolve.outcome == 'skipped'
-        run: echo 'Evolve patch loop skipped: tests already passing.' >> $GITHUB_STEP_SUMMARY
+        run: "echo 'Evolve patch loop skipped: tests already passing.' >> $GITHUB_STEP_SUMMARY"
 
       - name: Report evolve failure
         if: steps.evolve.outcome == 'failure'


### PR DESCRIPTION
## Summary
- ensure the 'Evolve skipped' step in the GitHub Actions workflow uses a single line `run` command to avoid YAML parsing issues

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842036d7ad4832796ff514d79c83cbe