### PR TITLE
Fix accuracy check to process all PDFs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,44 +104,34 @@ jobs:
         run: |
           pytest -ra -vv --cov=statement_refinery \
                  --cov-report=term-missing --cov-report=xml \
-                 --cov-fail-under=90
+                 --cov-fail-under=90 \
+                 --json-report --json-report-file=report.json
 
       - name: Check parser accuracy
         id: accuracy
         continue-on-error: true
-        run: python scripts/check_accuracy.py --threshold 99
+        run: python scripts/check_accuracy.py --threshold 99 --summary-file accuracy_summary.json --csv-dir csv_output
 
       # auto-patch loop runs only when tests or accuracy fail
-      - name: Validate evolve prerequisites
+      - name: Check evolve prerequisites
         id: evolve_prereqs
         if: |
           steps.tests.outcome == 'failure' ||
           steps.accuracy.outcome == 'failure'
-        run: |
-          python - <<'EOF'
-          import os, sys
-          try:
-              import openai  # noqa
-          except Exception:
-              sys.stderr.write('Missing `openai` package\n')
-              sys.exit(1)
-          if not os.getenv('OPENAI_API_KEY'):
-              sys.stderr.write('OPENAI_API_KEY not set\n')
-              sys.exit(1)
-          EOF
+        run: python scripts/check_evolve_prereqs.py
 
       - name: Evolve patch loop
         id: evolve
-        if: steps.evolve_prereqs.outcome == 'success'
+        if: |
+          (steps.tests.outcome == 'failure' ||
+           steps.accuracy.outcome == 'failure') &&
+          steps.evolve_prereqs.outcome == 'success'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
 
         run: python .github/tools/evolve.py
 
-      - name: Evolve skipped
-        if: steps.evolve.outcome == 'skipped'
-        run: "echo 'Evolve patch loop skipped: tests already passing.' >> $GITHUB_STEP_SUMMARY"
 
       - name: Report evolve failure
         if: steps.evolve.outcome == 'failure'
@@ -179,6 +169,23 @@ jobs:
           name: coverage-xml
           path: coverage.xml
 
+      - name: Upload generated CSVs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parser-csv
+          path: csv_output/
+
+      - name: Summarize results
+        if: always()
+        env:
+          STATIC_RESULT: ${{ needs.static.result }}
+          TESTS_OUTCOME: ${{ steps.tests.outcome }}
+          ACCURACY_OUTCOME: ${{ steps.accuracy.outcome }}
+          EVOLVE_PREREQS_OUTCOME: ${{ steps.evolve_prereqs.outcome }}
+          EVOLVE_OUTCOME: ${{ steps.evolve.outcome }}
+        run: python scripts/ci_summary.py
+
 
   golden-check:
     needs: tests-evolve
@@ -215,5 +222,5 @@ jobs:
         run: pip install -e '.[dev]'
 
       - name: Check parser accuracy
-        run: python scripts/check_accuracy.py
+        run: python scripts/check_accuracy.py --csv-dir csv_output
 

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,7 @@ itau_*.csv
 diagnostics/
 diagnostics/*.csv
 tests/debug/
+
+# Parser outputs
+csv_output/*
+!csv_output/.gitkeep

--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 import difflib
 import importlib.util
+import json
 import statistics
 import sys, os  # noqa: E401,F401
 
@@ -18,16 +19,22 @@ from statement_refinery import pdf_to_csv  # noqa: E402
 DATA_DIR = ROOT / "tests" / "data"
 
 
-def compare(pdf_path: Path) -> tuple[bool, float]:
+def compare(pdf_path: Path, out_dir: Path | None = None) -> tuple[bool, float]:
     """Run pdf_to_csv on *pdf_path* and compare to its golden CSV.
 
     Returns ``(mismatch, percentage)``.
     """
     print(f"\n=== {pdf_path.name} ===")
     buf = io.StringIO()
+    args = [str(pdf_path)]
+    out_path = None
+    if out_dir is not None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{pdf_path.stem}.csv"
+        args += ["--out", str(out_path)]
     with contextlib.redirect_stdout(buf):
         if HAS_PDFPLUMBER:
-            pdf_to_csv.main([str(pdf_path)])
+            pdf_to_csv.main(args)
             txt_file = pdf_path.with_suffix(".txt")
             if not txt_file.exists():
                 lines = list(pdf_to_csv.iter_pdf_lines(pdf_path))
@@ -40,7 +47,10 @@ def compare(pdf_path: Path) -> tuple[bool, float]:
             lines = txt.read_text().splitlines()
             rows = pdf_to_csv.parse_lines(iter(lines))
             pdf_to_csv.write_csv(rows, buf)
-    output_lines = buf.getvalue().splitlines()
+    if out_path is not None:
+        output_lines = out_path.read_text().splitlines()
+    else:
+        output_lines = buf.getvalue().splitlines()
 
     golden = pdf_path.with_name(f"golden_{pdf_path.stem.split('_')[-1]}.csv")
     if not golden.exists():
@@ -76,17 +86,29 @@ def main() -> None:
         default=99.0,
         help="fail if average match percentage is below this value",
     )
+    parser.add_argument(
+        "--summary-file",
+        default="accuracy_summary.json",
+        help="write JSON summary to this file",
+    )
+    parser.add_argument(
+        "--csv-dir",
+        default=None,
+        help="directory to write generated CSV files",
+    )
     args = parser.parse_args()
 
-    pdfs = sorted(DATA_DIR.glob("itau_*.pdf"))
+    pdfs = sorted(DATA_DIR.glob("[iI]tau_*.pdf"))
     if not pdfs:
         print("No PDFs found in tests/data.")
         return
 
     mismatched = False
     percentages = []
-    for pdf in pdfs:
-        mis, pct = compare(pdf)
+    total = len(pdfs)
+    for idx, pdf in enumerate(pdfs, 1):
+        print(f"\nProcessing {idx}/{total}: {pdf.name}")
+        mis, pct = compare(pdf, Path(args.csv_dir) if args.csv_dir else None)
         percentages.append(pct)
         if mis:
             mismatched = True
@@ -97,8 +119,13 @@ def main() -> None:
         print(f"Accuracy {avg:.2f}% below threshold {args.threshold}%")
         mismatched = True
 
+    summary = {"pdf_count": len(pdfs), "average": avg}
+    Path(args.summary_file).write_text(json.dumps(summary))
+
     if mismatched:
         raise SystemExit("mismatched parser output or low accuracy")
+
+    print("All PDF checks passed \N{PARTY POPPER}")
 
 
 if __name__ == "__main__":

--- a/scripts/check_evolve_prereqs.py
+++ b/scripts/check_evolve_prereqs.py
@@ -1,0 +1,21 @@
+import importlib
+import os
+import sys
+
+missing = False
+try:
+    importlib.import_module("openai")
+except Exception:
+    sys.stderr.write("Missing `openai` package\n")
+    missing = True
+
+if not os.getenv("OPENAI_API_KEY"):
+    sys.stderr.write("OPENAI_API_KEY not set\n")
+    missing = True
+
+if not os.getenv("PERSONAL_ACCESS_TOKEN_CLASSIC"):
+    sys.stderr.write("PERSONAL_ACCESS_TOKEN_CLASSIC not set\n")
+    missing = True
+
+if missing:
+    sys.exit(1)

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -1,0 +1,92 @@
+import json
+import os
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+summary_lines = []
+
+# Static checks result from env
+static_result = os.environ.get("STATIC_RESULT", "success")
+static_ok = static_result == "success"
+summary_lines.append(
+    f"{'\u2705' if static_ok else '\u274c'} Static checks: {'PASS' if static_ok else 'FAIL'}"
+)
+all_ok = static_ok
+
+# Unit tests
+tests_outcome = os.getenv("TESTS_OUTCOME", "success")
+try:
+    report = json.loads(Path("report.json").read_text())
+    total = report.get("summary", {}).get("total", 0)
+    passed = report.get("summary", {}).get("passed", 0)
+    skipped = total - passed
+except Exception:
+    total = passed = skipped = 0
+
+tests_ok = tests_outcome == "success" and skipped == 0
+summary_lines.append(
+    f"{'\u2705' if tests_ok else '\u274c'} Unit tests:    {'PASS' if tests_ok else 'FAIL'} ({skipped} skipped)"
+)
+all_ok = all_ok and tests_ok
+
+# Parser accuracy
+accuracy_outcome = os.getenv("ACCURACY_OUTCOME", "success")
+try:
+    acc = json.loads(Path("accuracy_summary.json").read_text())
+    pct = acc.get("average", 0.0)
+    count = acc.get("pdf_count", 0)
+except Exception:
+    pct = 0.0
+    count = 0
+accuracy_ok = accuracy_outcome == "success"
+summary_lines.append(
+    f"{'\u2705' if accuracy_ok else '\u274c'} Parser accuracy: {'PASS' if accuracy_ok else 'FAIL'} ({pct:.1f} %, {count} PDFs)"
+)
+all_ok = all_ok and accuracy_ok
+
+# Coverage
+cov_pct = 0.0
+try:
+    root = ET.parse("coverage.xml").getroot()
+    cov_pct = float(root.get("line-rate", 0)) * 100
+except Exception:
+    pass
+coverage_ok = cov_pct >= 90.0 and tests_outcome == "success"
+summary_lines.append(
+    f"{'\u2705' if coverage_ok else '\u274c'} Coverage:      {'PASS' if coverage_ok else 'FAIL'} ({cov_pct:.1f} %)"
+)
+all_ok = all_ok and coverage_ok
+
+# Evolve prerequisites
+prereq_outcome = os.getenv("EVOLVE_PREREQS_OUTCOME", "skipped")
+prereq_ok = prereq_outcome == "success"
+summary_lines.append(
+    f"{'\u2705' if prereq_ok else '\u274c'} Evolve prereqs: {'PASS' if prereq_ok else 'FAIL'}"
+)
+all_ok = all_ok and prereq_ok
+
+# Evolve loop
+loop_outcome = os.getenv("EVOLVE_OUTCOME", "skipped")
+if loop_outcome == "skipped":
+    loop_status = "SKIPPED (nothing to fix)"
+    loop_ok = True
+elif loop_outcome == "success":
+    loop_status = "RAN (build fixed)"
+    loop_ok = True
+else:
+    loop_status = "RAN (still red)"
+    loop_ok = False
+summary_lines.append(
+    f"{'\u2705' if loop_ok else '\u274c'} Evolve loop:   {loop_status}"
+)
+all_ok = all_ok and loop_ok
+
+summary_lines.append("")
+summary_lines.append(f"\U0001f3c1 RESULT: {'PARSER READY' if all_ok else 'NOT READY'}")
+
+with open(os.environ.get("GITHUB_STEP_SUMMARY", "summary.txt"), "a") as fh:
+    fh.write("\n".join(summary_lines) + "\n")
+
+if not all_ok:
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- emit end-of-job verdict summarizing all quality gates
- write accuracy results to a JSON summary file
- run tests with JSON report and generate CI summary
- keep parsed CSV outputs for inspection via workflow artifacts
- fix unicode encoding issue in summary script

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68420645d1f88327a97c636c868ff126