### PR TITLE
Fix CI prereqs and coverage upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,10 +184,13 @@ jobs:
         run: python scripts/check_accuracy.py --threshold 99
 
       - name: Upload coverage
-        if: always() && hashFiles('coverage.xml') != ''
+        if: always() && env.CODECOV_TOKEN != '' && hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v4
         with:
           files: coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact
         if: always()

--- a/scripts/check_evolve_prereqs.py
+++ b/scripts/check_evolve_prereqs.py
@@ -13,13 +13,19 @@ if not os.getenv("OPENAI_API_KEY"):
     sys.stderr.write("OPENAI_API_KEY not set\n")
     missing = True
 
-token = (
-    os.getenv("GITHUB_TOKEN")
-    or os.getenv("PERSONAL_ACCESS_TOKEN_CLASSIC")
-    or os.getenv("GH_TOKEN")
-)
-if not token:
+pat = os.getenv("PERSONAL_ACCESS_TOKEN_CLASSIC") or os.getenv("GH_TOKEN")
+gh_token = os.getenv("GITHUB_TOKEN")
+requires_pat = os.getenv("PROTECTED_BRANCH_PUSH", "false").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+if not (pat or gh_token):
     sys.stderr.write("Missing GitHub token\n")
+    missing = True
+elif requires_pat and not pat:
+    sys.stderr.write("PERSONAL_ACCESS_TOKEN_CLASSIC not set\n")
     missing = True
 
 if missing:

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -83,9 +83,7 @@ summary_lines.append(
 all_ok = all_ok and loop_ok
 
 summary_lines.append("")
-summary_lines.append(
-    f"\ud83c\udfd1 RESULT: {'PARSER READY' if all_ok else 'NOT READY'}"
-)
+summary_lines.append(f"\U0001f3d1 RESULT: {'PARSER READY' if all_ok else 'NOT READY'}")
 
 with open(
     os.environ.get("GITHUB_STEP_SUMMARY", "summary.txt"),


### PR DESCRIPTION
## Summary
- relax PAT checks so `GITHUB_TOKEN` works when permitted
- allow Codecov to skip upload when token missing
- fix emoji encoding in ci summary

## Testing
- `ruff check .`
- `black --check .`
- `mypy src/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842522b340c8327a1a4ff02e16d696a