### PR TITLE
Fix static checks

### DIFF
--- a/scripts/check_accuracy.py
+++ b/scripts/check_accuracy.py
@@ -58,7 +58,6 @@ def extract_total_from_pdf(pdf_path: Path) -> Decimal:
     raise ValueError(f"Could not find total in {pdf_path.name}")
 
 
-
 def compare(pdf_path: Path, out_dir: Path | None = None) -> tuple[bool, float]:
     """Run pdf_to_csv on *pdf_path* and compare to its golden CSV.
 

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -4,6 +4,10 @@ import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
+CHECK = "\N{WHITE HEAVY CHECK MARK}"
+CROSS = "\N{CROSS MARK}"
+ENCODING = "utf-8"
+
 
 FLAG = "\N{CHEQUERED FLAG}"
 


### PR DESCRIPTION
## Summary
- define `CHECK`, `CROSS`, and `ENCODING` constants
- reformat `check_accuracy.py`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -ra -vv --cov=statement_refinery`

------
https://chatgpt.com/codex/tasks/task_e_6842eb3d12848327b2e7f240a4f6b055