### PR TITLE
Fix workflow env usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ env:
   MAX_ATTEMPTS: '5'
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
+  FORCE_EVOLVE: '0'
 
 jobs:
   static:
@@ -71,7 +72,6 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GITHUB_TOKEN:   ${{ secrets.BOT_PAT }}
-      FORCE_EVOLVE: ${{ env.FORCE_EVOLVE }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- set `FORCE_EVOLVE` at the root env level
- drop `${{ env.FORCE_EVOLVE }}` reference from the tests job

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843139c2f288327a43cbdb21e39d2d1