### PR TITLE
Fix timezone warning in ci summary script

### DIFF
--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
@@ -88,7 +88,7 @@ summary_text = summary_text.encode(ENCODING, "replace").decode(ENCODING, "replac
 summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "summary.txt")
 diag_dir = Path("diagnostics")
 diag_dir.mkdir(exist_ok=True)
-diag_path = diag_dir / f"ci_summary_{datetime.utcnow().strftime('%Y%m%d')}.txt"
+diag_path = diag_dir / f"ci_summary_{datetime.now(UTC).strftime('%Y%m%d')}.txt"
 try:
     with open(summary_file, "w", encoding=ENCODING, errors="replace") as fh:
         fh.write(summary_text)


### PR DESCRIPTION
## Summary
- use timezone-aware datetime instead of deprecated `utcnow`

## Testing
- `ruff check .`
- `black --check .`
- `mypy src/`
- `pytest -ra -vv --cov=statement_refinery --cov-report=term-missing --cov-fail-under=90`
- `python scripts/check_accuracy.py`

------
https://chatgpt.com/codex/tasks/task_e_6843152e30748327a5a22a3cc8569522