### PR TITLE
Fix evolve gating and add diagnostics

### DIFF
--- a/.github/tools/evolve.py
+++ b/.github/tools/evolve.py
@@ -159,15 +159,10 @@ def load_best() -> Tuple[str, float]:
 def save_best(commit: str, best_score: float, tokens_used: int):
     SCORE_FILE.write_text(json.dumps({"commit": commit, "score": best_score}))
     print(f"🎉 New best! Commit {commit}  score={best_score:.1f}  tokens={tokens_used}")
-    with open(DIAG_DIR / "evolve_tokens.txt", "a", encoding="utf-8") as fh:
-        fh.write(f"{int(time.time())}\t{tokens_used}\n")
-
+    log_tokens_to_file(tokens_used)
 
 def record_tokens():
-    with open(DIAG_DIR / "evolve_tokens.txt", "a", encoding="utf-8") as fh:
-        fh.write(f"{int(time.time())}\t{TOKENS_USED}\n")
-
-
+    log_tokens_to_file(TOKENS_USED)
 # ───────────────────────── git helpers ─────────────────────────
 def ensure_best_branch() -> None:
     """Ensure BEST_BRANCH exists locally."""

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
           (steps.tests.outcome == 'failure' ||
            needs.static.result == 'failure' ||
            steps.accuracy.outcome == 'failure' ||
-           env.FORCE_EVOLVE == '1') &&
+           (env.FORCE_EVOLVE && env.FORCE_EVOLVE != '0')) &&
           steps.evolve_prereqs.outcome == 'success'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/tests/test_ci_summary_constants.py
+++ b/tests/test_ci_summary_constants.py
@@ -1,0 +1,15 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "ci_summary",
+    Path(__file__).resolve().parents[1] / "scripts" / "ci_summary.py",
+)
+assert spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)  # type: ignore
+
+
+def test_constants_present():
+    for name in ("CHECK", "CROSS", "ENCODING"):
+        assert hasattr(module, name)


### PR DESCRIPTION
## Summary
- harden evolve patch loop: check diff paths with `git ls-files`
- track OpenAI token usage in diagnostics
- run evolve when `FORCE_EVOLVE` is truthy
- add unit test ensuring CI symbols exist

## Testing
- `ruff check --fix .`
- `black .`
- `pytest -q`
- `python scripts/check_accuracy.py --summary-file accuracy_summary.json` *(fails: mismatched parser output)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6843417e9ae8832796fc13face176a77