### PR TITLE
Add sentinel test and evolve improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_EVOLVE: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -72,10 +74,12 @@ jobs:
       - name: Run auto-patch
         id: evolve
         if: |
-          (steps.lint.outcome == 'failure' ||
-           steps.tests.outcome == 'failure' ||
-           steps.accuracy.outcome == 'failure') &&
-          github.event_name != 'pull_request'
+          env.FORCE_EVOLVE == '1' || (
+            (steps.lint.outcome == 'failure' ||
+             steps.tests.outcome == 'failure' ||
+             steps.accuracy.outcome == 'failure') &&
+            github.event_name != 'pull_request'
+          )
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.BOT_PAT }}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ black src tests
 ruff check src tests
 ```
 
+## Auto-patch demo
+
+Pull requests with titles starting with `🤖 AUTO-FIX` were created by the
+evolve loop. Review the changes and merge once the automated checks pass.
+
 ## License
 
 MIT

--- a/tests/test_evolve_sentinel.py
+++ b/tests/test_evolve_sentinel.py
@@ -1,0 +1,2 @@
+def test_sentinel_fails():
+    assert False, "Sentinel failure that Codex must patch"


### PR DESCRIPTION
## Summary
- force evolve job by setting `FORCE_EVOLVE=1`
- add sentinel failing test
- improve evolve.py with fallback branch handling and patch validation
- document auto-fix PRs in README
- allow evolve step to run on pull requests

## Testing
- `ruff check .github/tools/evolve.py tests/test_evolve_sentinel.py`
- `black .github/tools/evolve.py tests/test_evolve_sentinel.py`
- `pytest -q` *(fails: test_sentinel_fails)*

------
https://chatgpt.com/codex/tasks/task_e_6843ea63b3dc8327a59169c1506477dc